### PR TITLE
TID/SID Finder Implementation

### DIFF
--- a/SWSH_OWRNG_Generator_GUI/Frame.cs
+++ b/SWSH_OWRNG_Generator_GUI/Frame.cs
@@ -4,6 +4,8 @@
     {
         public string Advances { get; set; }
 
+        public ushort TID { get; set; }
+        public ushort SID { get; set; }
         public ulong Animation { get; set; }
         public uint Level { get; set; }
         public uint Slot { get; set; }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
@@ -75,6 +75,8 @@ namespace SWSH_OWRNG_Generator_GUI
             this.LabelShiny = new System.Windows.Forms.Label();
             this.Results = new System.Windows.Forms.DataGridView();
             this.Frame = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.TID = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.SID = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Animation = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Level = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.Slot = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -137,6 +139,7 @@ namespace SWSH_OWRNG_Generator_GUI
             this.MainMenu = new System.Windows.Forms.MainMenu(this.components);
             this.SeedFinderMenu = new System.Windows.Forms.MenuItem();
             this.ButtonUpdateStates = new System.Windows.Forms.Button();
+            this.CheckTIDSIDFinder = new System.Windows.Forms.CheckBox();
             ((System.ComponentModel.ISupportInitialize)(this.ImageRareMark)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.Results)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.generatorBindingSource)).BeginInit();
@@ -616,6 +619,8 @@ namespace SWSH_OWRNG_Generator_GUI
             this.Results.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
             this.Results.Columns.AddRange(new System.Windows.Forms.DataGridViewColumn[] {
             this.Frame,
+            this.TID,
+            this.SID,
             this.Animation,
             this.Level,
             this.Slot,
@@ -649,6 +654,26 @@ namespace SWSH_OWRNG_Generator_GUI
             this.Frame.Name = "Frame";
             this.Frame.ReadOnly = true;
             this.Frame.Width = 150;
+            // 
+            // TID
+            // 
+            this.TID.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.TID.DataPropertyName = "TID";
+            this.TID.HeaderText = "TID";
+            this.TID.MinimumWidth = 8;
+            this.TID.Name = "TID";
+            this.TID.ReadOnly = true;
+            this.TID.Width = 50;
+            // 
+            // SID
+            // 
+            this.SID.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.SID.DataPropertyName = "SID";
+            this.SID.HeaderText = "SID";
+            this.SID.MinimumWidth = 8;
+            this.SID.Name = "SID";
+            this.SID.ReadOnly = true;
+            this.SID.Width = 50;
             // 
             // Animation
             // 
@@ -813,10 +838,6 @@ namespace SWSH_OWRNG_Generator_GUI
             this.State1.Name = "State1";
             this.State1.ReadOnly = true;
             this.State1.Width = 150;
-            // 
-            // generatorBindingSource
-            // 
-            this.generatorBindingSource.DataSource = typeof(SWSH_OWRNG_Generator_GUI.Generator);
             // 
             // label12
             // 
@@ -1245,10 +1266,22 @@ namespace SWSH_OWRNG_Generator_GUI
             this.ButtonUpdateStates.UseVisualStyleBackColor = true;
             this.ButtonUpdateStates.Click += new System.EventHandler(this.ButtonUpdateStates_Click);
             // 
-            // Form
+            // CheckTIDSIDFinder
+            // 
+            this.CheckTIDSIDFinder.AutoSize = true;
+            this.CheckTIDSIDFinder.Location = new System.Drawing.Point(12, 62);
+            this.CheckTIDSIDFinder.Name = "CheckTIDSIDFinder";
+            this.CheckTIDSIDFinder.Size = new System.Drawing.Size(122, 17);
+            this.CheckTIDSIDFinder.TabIndex = 90;
+            this.CheckTIDSIDFinder.Text = "Search For TID/SID";
+            this.CheckTIDSIDFinder.UseVisualStyleBackColor = true;
+            this.CheckTIDSIDFinder.CheckedChanged += new System.EventHandler(this.CheckTIDSIDFinder_CheckedChanged);
+            // 
+            // MainWindow
             // 
             this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(769, 540);
+            this.Controls.Add(this.CheckTIDSIDFinder);
             this.Controls.Add(this.ButtonUpdateStates);
             this.Controls.Add(this.CheckIsLegend);
             this.Controls.Add(this.RetailAdvancesTrackerNumResultsLabel);
@@ -1337,7 +1370,7 @@ namespace SWSH_OWRNG_Generator_GUI
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Menu = this.MainMenu;
-            this.Name = "Form";
+            this.Name = "MainWindow";
             this.Load += new System.EventHandler(this.Form1_Load);
             ((System.ComponentModel.ISupportInitialize)(this.ImageRareMark)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.Results)).EndInit();
@@ -1433,6 +1466,11 @@ namespace SWSH_OWRNG_Generator_GUI
         private System.Windows.Forms.TextBox RetailAdvancesTrackerResultState1;
         private System.Windows.Forms.Label label2;
         private System.Windows.Forms.Label RetailAdvancesTrackerNumResultsLabel;
+        private System.Windows.Forms.CheckBox CheckIsLegend;
+        private System.Windows.Forms.MainMenu MainMenu;
+        private System.Windows.Forms.MenuItem SeedFinderMenu;
+        private System.Windows.Forms.Button ButtonUpdateStates;
+        private System.Windows.Forms.CheckBox CheckTIDSIDFinder;
         private System.Windows.Forms.DataGridViewTextBoxColumn Frame;
         private System.Windows.Forms.DataGridViewTextBoxColumn Animation;
         private System.Windows.Forms.DataGridViewTextBoxColumn Level;
@@ -1449,11 +1487,9 @@ namespace SWSH_OWRNG_Generator_GUI
         private System.Windows.Forms.DataGridViewTextBoxColumn SpD;
         private System.Windows.Forms.DataGridViewTextBoxColumn Spe;
         private System.Windows.Forms.DataGridViewTextBoxColumn Mark;
+        private System.Windows.Forms.DataGridViewTextBoxColumn TID;
+        private System.Windows.Forms.DataGridViewTextBoxColumn SID;
         private System.Windows.Forms.DataGridViewTextBoxColumn State0;
         private System.Windows.Forms.DataGridViewTextBoxColumn State1;
-        private System.Windows.Forms.CheckBox CheckIsLegend;
-        private System.Windows.Forms.MainMenu MainMenu;
-        private System.Windows.Forms.MenuItem SeedFinderMenu;
-        private System.Windows.Forms.Button ButtonUpdateStates;
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -443,6 +443,7 @@ namespace SWSH_OWRNG_Generator_GUI
             bool HeldItem = CheckHeldItem.Checked;
             bool ExtraRoll = CheckExtraRoll.Checked;
             bool IsLegend = CheckIsLegend.Checked;
+            bool TIDSIDSearch = CheckTIDSIDFinder.Checked;
             string DesiredMark = (string)SelectedMark.SelectedItem;
             string DesiredShiny = (string)SelectedShiny.SelectedItem;
             uint[] MinIVs = { UInt16.Parse(hpMin.Text), UInt16.Parse(atkMin.Text), UInt16.Parse(defMin.Text), UInt16.Parse(spaMin.Text), UInt16.Parse(spdMin.Text), UInt16.Parse(speMin.Text) };
@@ -478,6 +479,8 @@ namespace SWSH_OWRNG_Generator_GUI
             Results.Columns["Level"].Visible = !Static;
             Results.Columns["Slot"].Visible = !Static;
             Results.Columns["Ability"].Visible = !IsLegend;
+            Results.Columns["TID"].Visible = TIDSIDSearch;
+            Results.Columns["SID"].Visible = TIDSIDSearch;
 
             progressBar1.Value = 0;
             progressBar1.Maximum = (int)advances;
@@ -490,7 +493,7 @@ namespace SWSH_OWRNG_Generator_GUI
 
             List<Frame> Frames = await Task.Run(() => Generator.Generate(
                 s0, s1, advances, TID, SID, ShinyCharm, MarkCharm, Weather, Static, Fishing, HeldItem, ExtraRoll, DesiredMark, DesiredShiny,
-                LevelMin, LevelMax, SlotMin, SlotMax, MinIVs, MaxIVs, IsLegend, progress
+                LevelMin, LevelMax, SlotMin, SlotMax, MinIVs, MaxIVs, IsLegend, TIDSIDSearch, progress
             ));
             BindingSource Source = new BindingSource { DataSource = Frames };
             Results.DataSource = Source;
@@ -606,6 +609,16 @@ namespace SWSH_OWRNG_Generator_GUI
                     this.InputState1.Text = form1.State1;
                 }
             }
+        }
+
+        private void CheckTIDSIDFinder_CheckedChanged(object sender, EventArgs e)
+        {
+            bool check = this.CheckTIDSIDFinder.Checked;
+            this.LabelTID.Enabled = !check;
+            this.InputTID.Enabled = !check;
+            this.LabelSID.Enabled = !check;
+            this.InputSID.Enabled = !check;
+            this.SelectedShiny.Enabled = !check;
         }
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -630,6 +630,7 @@ namespace SWSH_OWRNG_Generator_GUI
             this.LabelSID.Enabled = !check;
             this.InputSID.Enabled = !check;
             this.SelectedShiny.Enabled = !check;
+            this.LabelShiny.Enabled = !check;
         }
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.resx
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.resx
@@ -120,6 +120,12 @@
   <metadata name="Frame.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>
+  <metadata name="TID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
+  <metadata name="SID.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <metadata name="Animation.UserAddedColumn" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>True</value>
   </metadata>

--- a/SWSH_OWRNG_Generator_GUI/Xoroshiro.cs
+++ b/SWSH_OWRNG_Generator_GUI/Xoroshiro.cs
@@ -33,6 +33,20 @@
             return result;
         }
 
+        public ulong previous()
+        {
+            ulong s0 = state0;
+            ulong s1 = state1;
+            s1 = RotateLeft(s1, 27);
+            s0 = s0 ^ s1 ^ (s1 << 16);
+            s0 = RotateLeft(s0, 40);
+            s1 ^= s0;
+            state0 = s0;
+            state1 = s1;
+            ulong result = s0 + s1;
+            return result;
+        }
+
         public uint nextuint()
         {
             return (uint)next();


### PR DESCRIPTION
The purpose of this PR is to implement the functionality of finding your tid/sid pure retail.

Checking the "Search For TID/SID" box makes the generator advance backwards from the current state with the provided filters. Once its found a frame that matches the filters, it will provide a mock tid/sid that would make that frame shiny.

The idea is that like with the JPN tool, you would find a shiny, find your current state after catching it, filter for IVs/Nature/Etc., and check the previous X frames for the shiny you hit.