### PR TITLE
Add direct download badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # swsh-overworld-rng-gui
-[![.NET Core Desktop](https://github.com/LegoFigure11/swsh-overworld-rng-gui/actions/workflows/dotnet-desktop.yml/badge.svg)](https://github.com/LegoFigure11/swsh-overworld-rng-gui/actions/workflows/dotnet-desktop.yml) [![GitHub License](https://img.shields.io/github/license/legofigure11/swsh-overworld-rng-gui?color=ff69b4)](https://github.com/LegoFigure11/swsh-overworld-rng-gui/blob/main/LICENSE)
-
-[![](https://img.shields.io/badge/Latest%20Commit-Direct%20Download-brightgreen)](https://nightly.link/LegoFigure11/swsh-overworld-rng-gui/workflows/dotnet-desktop/main/SWSH-Overworld-RNG-GUI.zip)
+[![.NET Core Desktop](https://github.com/LegoFigure11/swsh-overworld-rng-gui/actions/workflows/dotnet-desktop.yml/badge.svg)](https://github.com/LegoFigure11/swsh-overworld-rng-gui/actions/workflows/dotnet-desktop.yml) [![GitHub License](https://img.shields.io/github/license/legofigure11/swsh-overworld-rng-gui?color=ff69b4)](https://github.com/LegoFigure11/swsh-overworld-rng-gui/blob/main/LICENSE) [![Nightly Link](https://img.shields.io/badge/Latest%20Commit-Direct%20Download-blue)](https://nightly.link/LegoFigure11/swsh-overworld-rng-gui/workflows/dotnet-desktop/main/SWSH-Overworld-RNG-GUI.zip)
 
 _by [@LegoFigure11](https://github.com/LegoFigure11/) and [@shinyfinder](https://github.com/shinyfinder/)_
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # swsh-overworld-rng-gui
 [![.NET Core Desktop](https://github.com/LegoFigure11/swsh-overworld-rng-gui/actions/workflows/dotnet-desktop.yml/badge.svg)](https://github.com/LegoFigure11/swsh-overworld-rng-gui/actions/workflows/dotnet-desktop.yml) [![GitHub License](https://img.shields.io/github/license/legofigure11/swsh-overworld-rng-gui?color=ff69b4)](https://github.com/LegoFigure11/swsh-overworld-rng-gui/blob/main/LICENSE)
 
+[![](https://img.shields.io/badge/Latest%20Commit-Direct%20Download-brightgreen)](https://nightly.link/LegoFigure11/swsh-overworld-rng-gui/workflows/dotnet-desktop/main/SWSH-Overworld-RNG-GUI.zip)
+
 _by [@LegoFigure11](https://github.com/LegoFigure11/) and [@shinyfinder](https://github.com/shinyfinder/)_
 
 This program is designed for searching for Overworld RNG targets in Pokémon Sword and Shield.


### PR DESCRIPTION
This PR adds a badge to directly download the latest github actions build to the readme.
[![](https://img.shields.io/badge/Latest%20Commit-Direct%20Download-brightgreen)](https://nightly.link/LegoFigure11/swsh-overworld-rng-gui/workflows/dotnet-desktop/main/SWSH-Overworld-RNG-GUI.zip)
On click it will direct the user to the https://nightly.link/ link for the repository (https://nightly.link/LegoFigure11/swsh-overworld-rng-gui/workflows/dotnet-desktop/main/SWSH-Overworld-RNG-GUI.zip) in order to make the latest artifact easier to download for users and without needing to sign in. It's recommended to also install the [github app](https://github.com/apps/nightly-link) for nightly.link so it can access artifacts easier.