### PR TITLE
Add comma and period keys as 0 1 input options

### DIFF
--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -418,6 +418,16 @@ namespace SWSH_OWRNG_Generator_GUI
         {
             string s = "";
 
+            if (e.KeyChar == ',')
+            {
+                e.KeyChar = '0';
+            }
+
+            else if (e.KeyChar == '.')
+            {
+                e.KeyChar = '1';
+            }
+
             s += e.KeyChar;
 
             byte[] b = Encoding.ASCII.GetBytes(s);

--- a/SWSH_OWRNG_Generator_GUI/SeedFinder.cs
+++ b/SWSH_OWRNG_Generator_GUI/SeedFinder.cs
@@ -126,6 +126,16 @@ namespace SWSH_OWRNG_Generator_GUI
         {
             string s = "";
 
+            if (e.KeyChar == ',')
+            {
+                e.KeyChar = '0';
+            }
+
+            else if (e.KeyChar == '.')
+            {
+                e.KeyChar = '1';
+            }
+
             s += e.KeyChar;
 
             byte[] b = Encoding.ASCII.GetBytes(s);


### PR DESCRIPTION
The purpose of this PR is to provide a convenient input option for entering the sequence animations into the Seed Finder and Retail Advances Tracker. On many keyboards, the 0 and 1 key are not side by side, so providing the `,` and `.` keys to serve as alternative options allows for easier and faster input while looking at the game screen.