### PR TITLE
Add IV judge and nature filters

### DIFF
--- a/SWSH_OWRNG_Generator_GUI/Generator.cs
+++ b/SWSH_OWRNG_Generator_GUI/Generator.cs
@@ -286,7 +286,6 @@ namespace SWSH_OWRNG_Generator_GUI
         private static bool PassesNatureFilter(string Nature, string DesiredNature)
         {
             return ((DesiredNature == Nature) || (DesiredNature == "Ignore"));
-            //return !((DesiredMark == "Any Mark" && Mark == "None") || (DesiredMark == "Any Personality" && (Mark == "None" || Mark == "Uncommon" || Mark == "Time" || Mark == "Weather" || Mark == "Fishing" || Mark == "Rare")) || (DesiredMark != "Ignore" && DesiredMark != "Any Mark" && DesiredMark != "Any Personality" && Mark != DesiredMark));
         }
 
         private static (uint, uint) GenerateBrilliantInfo(uint KOs)

--- a/SWSH_OWRNG_Generator_GUI/Generator.cs
+++ b/SWSH_OWRNG_Generator_GUI/Generator.cs
@@ -164,34 +164,34 @@ namespace SWSH_OWRNG_Generator_GUI
                     continue;
                 }
 
-                    // Passes all filters!
-                    Results.Add(
-                    new Frame()
-                    {
-                        Advances = TIDSIDSearch ? (-(long)advance).ToString("N0") : advance.ToString("N0"),
-                        TID = (ushort)(MockPID >> 16),
-                        SID = (ushort)MockPID,
-                        Animation = go.state0 & 1 ^ go.state1 & 1,
-                        Level = Level,
-                        Slot = SlotRand,
-                        PID = PID.ToString("X8"),
-                        EC = EC.ToString("X8"),
-                        Shiny = ShinyXOR == 0 ? "Square" : (ShinyXOR < 16 ? "Star" : "No"),
-                        Brilliant = Brilliant ? "Y" : "-",
-                        Ability = AbilityRoll == 0 ? 1 : 0,
-                        Nature = Natures[Nature],
-                        Gender = Gender,
-                        HP = IVs[0],
-                        Atk = IVs[1],
-                        Def = IVs[2],
-                        SpA = IVs[3],
-                        SpD = IVs[4],
-                        Spe = IVs[5],
-                        Mark = Mark,
-                        State0 = go.state0.ToString("X16"),
-                        State1 = go.state1.ToString("X16"),
-                    }
-                );
+                // Passes all filters!
+                Results.Add(
+                new Frame()
+                {
+                    Advances = TIDSIDSearch ? (-(long)advance).ToString("N0") : advance.ToString("N0"),
+                    TID = (ushort)(MockPID >> 16),
+                    SID = (ushort)MockPID,
+                    Animation = go.state0 & 1 ^ go.state1 & 1,
+                    Level = Level,
+                    Slot = SlotRand,
+                    PID = PID.ToString("X8"),
+                    EC = EC.ToString("X8"),
+                    Shiny = ShinyXOR == 0 ? "Square" : (ShinyXOR < 16 ? "Star" : "No"),
+                    Brilliant = Brilliant ? "Y" : "-",
+                    Ability = AbilityRoll == 0 ? 1 : 0,
+                    Nature = Natures[Nature],
+                    Gender = Gender,
+                    HP = IVs[0],
+                    Atk = IVs[1],
+                    Def = IVs[2],
+                    SpA = IVs[3],
+                    SpD = IVs[4],
+                    Spe = IVs[5],
+                    Mark = Mark,
+                    State0 = go.state0.ToString("X16"),
+                    State1 = go.state1.ToString("X16"),
+                }
+            );
 
                 if (TIDSIDSearch)
                     go.previous();

--- a/SWSH_OWRNG_Generator_GUI/Generator.cs
+++ b/SWSH_OWRNG_Generator_GUI/Generator.cs
@@ -12,7 +12,7 @@ namespace SWSH_OWRNG_Generator_GUI
         // Heavily derived from https://github.com/Lincoln-LM/PyNXReader/
         public static List<Frame> Generate(
             ulong state0, ulong state1, ulong advances, uint TID, uint SID, bool ShinyCharm, bool MarkCharm, bool Weather,
-            bool Static, bool Fishing, bool HeldItem, string DesiredMark, string DesiredShiny, uint LevelMin,
+            bool Static, bool Fishing, bool HeldItem, string DesiredMark, string DesiredShiny, string DesiredNature, uint LevelMin,
             uint LevelMax, uint SlotMin, uint SlotMax, uint[] MinIVs, uint[] MaxIVs, bool IsAbilityLocked, uint EggMoveCount,
             uint KOs, uint FlawlessIVs, bool IsCuteCharm, bool TIDSIDSearch, IProgress<int> progress
             )
@@ -154,8 +154,18 @@ namespace SWSH_OWRNG_Generator_GUI
                     continue;
                 }
 
-                // Passes all filters!
-                Results.Add(
+                if (!PassesNatureFilter(Natures[Nature], DesiredNature))
+                {
+                    if (TIDSIDSearch)
+                        go.previous();
+                    else
+                        go.next();
+                    advance += 1;
+                    continue;
+                }
+
+                    // Passes all filters!
+                    Results.Add(
                     new Frame()
                     {
                         Advances = TIDSIDSearch ? (-(long)advance).ToString("N0") : advance.ToString("N0"),
@@ -271,6 +281,12 @@ namespace SWSH_OWRNG_Generator_GUI
         private static bool PassesMarkFilter(string Mark, string DesiredMark)
         {
             return !((DesiredMark == "Any Mark" && Mark == "None") || (DesiredMark == "Any Personality" && (Mark == "None" || Mark == "Uncommon" || Mark == "Time" || Mark == "Weather" || Mark == "Fishing" || Mark == "Rare")) || (DesiredMark != "Ignore" && DesiredMark != "Any Mark" && DesiredMark != "Any Personality" && Mark != DesiredMark));
+        }
+
+        private static bool PassesNatureFilter(string Nature, string DesiredNature)
+        {
+            return ((DesiredNature == Nature) || (DesiredNature == "Ignore"));
+            //return !((DesiredMark == "Any Mark" && Mark == "None") || (DesiredMark == "Any Personality" && (Mark == "None" || Mark == "Uncommon" || Mark == "Time" || Mark == "Weather" || Mark == "Fishing" || Mark == "Rare")) || (DesiredMark != "Ignore" && DesiredMark != "Any Mark" && DesiredMark != "Any Personality" && Mark != DesiredMark));
         }
 
         private static (uint, uint) GenerateBrilliantInfo(uint KOs)

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
@@ -149,12 +149,6 @@ namespace SWSH_OWRNG_Generator_GUI
             this.InputFlawlessIVs = new System.Windows.Forms.TextBox();
             this.sensBox = new System.Windows.Forms.CheckBox();
             this.CheckCuteCharm = new System.Windows.Forms.CheckBox();
-            this.hpResetFilter = new System.Windows.Forms.Button();
-            this.atkResetFilter = new System.Windows.Forms.Button();
-            this.defResetFilter = new System.Windows.Forms.Button();
-            this.spaResetFilter = new System.Windows.Forms.Button();
-            this.spdResetFilter = new System.Windows.Forms.Button();
-            this.speResetFilter = new System.Windows.Forms.Button();
             this.hpJudgeFilter = new System.Windows.Forms.ComboBox();
             this.atkJudgeFilter = new System.Windows.Forms.ComboBox();
             this.defJudgeFilter = new System.Windows.Forms.ComboBox();
@@ -664,7 +658,7 @@ namespace SWSH_OWRNG_Generator_GUI
             this.Results.Name = "Results";
             this.Results.ReadOnly = true;
             this.Results.RowHeadersWidth = 62;
-            this.Results.Size = new System.Drawing.Size(954, 166);
+            this.Results.Size = new System.Drawing.Size(808, 166);
             this.Results.TabIndex = 73;
             // 
             // Frame
@@ -1152,7 +1146,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             this.RetailAdvancesTrackerLabel.AutoSize = true;
             this.RetailAdvancesTrackerLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.RetailAdvancesTrackerLabel.Location = new System.Drawing.Point(755, 24);
+            this.RetailAdvancesTrackerLabel.Location = new System.Drawing.Point(602, 8);
             this.RetailAdvancesTrackerLabel.Name = "RetailAdvancesTrackerLabel";
             this.RetailAdvancesTrackerLabel.Size = new System.Drawing.Size(148, 13);
             this.RetailAdvancesTrackerLabel.TabIndex = 75;
@@ -1161,7 +1155,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // RetailAdvancesTrackerInitialInputLabel
             // 
             this.RetailAdvancesTrackerInitialInputLabel.AutoSize = true;
-            this.RetailAdvancesTrackerInitialInputLabel.Location = new System.Drawing.Point(755, 50);
+            this.RetailAdvancesTrackerInitialInputLabel.Location = new System.Drawing.Point(602, 34);
             this.RetailAdvancesTrackerInitialInputLabel.Name = "RetailAdvancesTrackerInitialInputLabel";
             this.RetailAdvancesTrackerInitialInputLabel.Size = new System.Drawing.Size(59, 13);
             this.RetailAdvancesTrackerInitialInputLabel.TabIndex = 76;
@@ -1170,7 +1164,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // RetailAdvancesTrackerMaxAdvInputLabel
             // 
             this.RetailAdvancesTrackerMaxAdvInputLabel.AutoSize = true;
-            this.RetailAdvancesTrackerMaxAdvInputLabel.Location = new System.Drawing.Point(801, 76);
+            this.RetailAdvancesTrackerMaxAdvInputLabel.Location = new System.Drawing.Point(648, 60);
             this.RetailAdvancesTrackerMaxAdvInputLabel.Name = "RetailAdvancesTrackerMaxAdvInputLabel";
             this.RetailAdvancesTrackerMaxAdvInputLabel.Size = new System.Drawing.Size(13, 13);
             this.RetailAdvancesTrackerMaxAdvInputLabel.TabIndex = 77;
@@ -1178,7 +1172,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // RetailAdvancesTrackerInitialInput
             // 
-            this.RetailAdvancesTrackerInitialInput.Location = new System.Drawing.Point(820, 47);
+            this.RetailAdvancesTrackerInitialInput.Location = new System.Drawing.Point(667, 31);
             this.RetailAdvancesTrackerInitialInput.MaxLength = 16;
             this.RetailAdvancesTrackerInitialInput.Name = "RetailAdvancesTrackerInitialInput";
             this.RetailAdvancesTrackerInitialInput.Size = new System.Drawing.Size(145, 20);
@@ -1189,7 +1183,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // RetailAdvancesTrackerMaxInput
             // 
-            this.RetailAdvancesTrackerMaxInput.Location = new System.Drawing.Point(820, 73);
+            this.RetailAdvancesTrackerMaxInput.Location = new System.Drawing.Point(667, 57);
             this.RetailAdvancesTrackerMaxInput.MaxLength = 16;
             this.RetailAdvancesTrackerMaxInput.Name = "RetailAdvancesTrackerMaxInput";
             this.RetailAdvancesTrackerMaxInput.Size = new System.Drawing.Size(145, 20);
@@ -1200,7 +1194,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // RetailAdvancesTrackerGenerateButton
             // 
-            this.RetailAdvancesTrackerGenerateButton.Location = new System.Drawing.Point(758, 106);
+            this.RetailAdvancesTrackerGenerateButton.Location = new System.Drawing.Point(605, 90);
             this.RetailAdvancesTrackerGenerateButton.Name = "RetailAdvancesTrackerGenerateButton";
             this.RetailAdvancesTrackerGenerateButton.Size = new System.Drawing.Size(207, 20);
             this.RetailAdvancesTrackerGenerateButton.TabIndex = 80;
@@ -1211,14 +1205,14 @@ namespace SWSH_OWRNG_Generator_GUI
             // RetailAdvancesTrackerProgressBar
             // 
             this.RetailAdvancesTrackerProgressBar.ForeColor = System.Drawing.SystemColors.ActiveCaption;
-            this.RetailAdvancesTrackerProgressBar.Location = new System.Drawing.Point(759, 130);
+            this.RetailAdvancesTrackerProgressBar.Location = new System.Drawing.Point(606, 114);
             this.RetailAdvancesTrackerProgressBar.Name = "RetailAdvancesTrackerProgressBar";
             this.RetailAdvancesTrackerProgressBar.Size = new System.Drawing.Size(205, 10);
             this.RetailAdvancesTrackerProgressBar.TabIndex = 81;
             // 
             // RetailAdvancesTrackerSequenceInput
             // 
-            this.RetailAdvancesTrackerSequenceInput.Location = new System.Drawing.Point(758, 167);
+            this.RetailAdvancesTrackerSequenceInput.Location = new System.Drawing.Point(605, 151);
             this.RetailAdvancesTrackerSequenceInput.MaxLength = 30;
             this.RetailAdvancesTrackerSequenceInput.Name = "RetailAdvancesTrackerSequenceInput";
             this.RetailAdvancesTrackerSequenceInput.ReadOnly = true;
@@ -1230,7 +1224,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // RetailAdvancesTrackerSequenceLabel
             // 
             this.RetailAdvancesTrackerSequenceLabel.AutoSize = true;
-            this.RetailAdvancesTrackerSequenceLabel.Location = new System.Drawing.Point(755, 151);
+            this.RetailAdvancesTrackerSequenceLabel.Location = new System.Drawing.Point(602, 135);
             this.RetailAdvancesTrackerSequenceLabel.Name = "RetailAdvancesTrackerSequenceLabel";
             this.RetailAdvancesTrackerSequenceLabel.Size = new System.Drawing.Size(199, 13);
             this.RetailAdvancesTrackerSequenceLabel.TabIndex = 83;
@@ -1238,7 +1232,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // RetailAdvancesTrackerResultState0
             // 
-            this.RetailAdvancesTrackerResultState0.Location = new System.Drawing.Point(758, 252);
+            this.RetailAdvancesTrackerResultState0.Location = new System.Drawing.Point(605, 236);
             this.RetailAdvancesTrackerResultState0.MaxLength = 16;
             this.RetailAdvancesTrackerResultState0.Name = "RetailAdvancesTrackerResultState0";
             this.RetailAdvancesTrackerResultState0.ReadOnly = true;
@@ -1249,7 +1243,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(755, 279);
+            this.label3.Location = new System.Drawing.Point(602, 263);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(84, 13);
             this.label3.TabIndex = 87;
@@ -1257,7 +1251,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // RetailAdvancesTrackerResultState1
             // 
-            this.RetailAdvancesTrackerResultState1.Location = new System.Drawing.Point(758, 295);
+            this.RetailAdvancesTrackerResultState1.Location = new System.Drawing.Point(605, 279);
             this.RetailAdvancesTrackerResultState1.MaxLength = 16;
             this.RetailAdvancesTrackerResultState1.Name = "RetailAdvancesTrackerResultState1";
             this.RetailAdvancesTrackerResultState1.ReadOnly = true;
@@ -1268,7 +1262,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(755, 236);
+            this.label2.Location = new System.Drawing.Point(602, 220);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(84, 13);
             this.label2.TabIndex = 85;
@@ -1277,7 +1271,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // RetailAdvancesTrackerNumResultsLabel
             // 
             this.RetailAdvancesTrackerNumResultsLabel.AutoSize = true;
-            this.RetailAdvancesTrackerNumResultsLabel.Location = new System.Drawing.Point(755, 204);
+            this.RetailAdvancesTrackerNumResultsLabel.Location = new System.Drawing.Point(602, 188);
             this.RetailAdvancesTrackerNumResultsLabel.Name = "RetailAdvancesTrackerNumResultsLabel";
             this.RetailAdvancesTrackerNumResultsLabel.Size = new System.Drawing.Size(110, 13);
             this.RetailAdvancesTrackerNumResultsLabel.TabIndex = 88;
@@ -1306,7 +1300,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // ButtonUpdateStates
             // 
-            this.ButtonUpdateStates.Location = new System.Drawing.Point(757, 321);
+            this.ButtonUpdateStates.Location = new System.Drawing.Point(604, 305);
             this.ButtonUpdateStates.Name = "ButtonUpdateStates";
             this.ButtonUpdateStates.Size = new System.Drawing.Size(209, 20);
             this.ButtonUpdateStates.TabIndex = 89;
@@ -1410,66 +1404,6 @@ namespace SWSH_OWRNG_Generator_GUI
             this.CheckCuteCharm.Text = "Cute Charm Lead";
             this.CheckCuteCharm.UseVisualStyleBackColor = true;
             // 
-            // hpResetFilter
-            // 
-            this.hpResetFilter.Location = new System.Drawing.Point(649, 5);
-            this.hpResetFilter.Name = "hpResetFilter";
-            this.hpResetFilter.Size = new System.Drawing.Size(43, 20);
-            this.hpResetFilter.TabIndex = 98;
-            this.hpResetFilter.Text = "Reset";
-            this.hpResetFilter.UseVisualStyleBackColor = true;
-            this.hpResetFilter.Click += new System.EventHandler(this.HpResetFilter_Click);
-            // 
-            // atkResetFilter
-            // 
-            this.atkResetFilter.Location = new System.Drawing.Point(649, 32);
-            this.atkResetFilter.Name = "atkResetFilter";
-            this.atkResetFilter.Size = new System.Drawing.Size(43, 20);
-            this.atkResetFilter.TabIndex = 99;
-            this.atkResetFilter.Text = "Reset";
-            this.atkResetFilter.UseVisualStyleBackColor = true;
-            this.atkResetFilter.Click += new System.EventHandler(this.AtkResetFilter_Click);
-            // 
-            // defResetFilter
-            // 
-            this.defResetFilter.Location = new System.Drawing.Point(649, 58);
-            this.defResetFilter.Name = "defResetFilter";
-            this.defResetFilter.Size = new System.Drawing.Size(43, 20);
-            this.defResetFilter.TabIndex = 100;
-            this.defResetFilter.Text = "Reset";
-            this.defResetFilter.UseVisualStyleBackColor = true;
-            this.defResetFilter.Click += new System.EventHandler(this.DefResetFilter_Click);
-            // 
-            // spaResetFilter
-            // 
-            this.spaResetFilter.Location = new System.Drawing.Point(649, 84);
-            this.spaResetFilter.Name = "spaResetFilter";
-            this.spaResetFilter.Size = new System.Drawing.Size(43, 20);
-            this.spaResetFilter.TabIndex = 101;
-            this.spaResetFilter.Text = "Reset";
-            this.spaResetFilter.UseVisualStyleBackColor = true;
-            this.spaResetFilter.Click += new System.EventHandler(this.SpaResetFilter_Click);
-            // 
-            // spdResetFilter
-            // 
-            this.spdResetFilter.Location = new System.Drawing.Point(649, 110);
-            this.spdResetFilter.Name = "spdResetFilter";
-            this.spdResetFilter.Size = new System.Drawing.Size(43, 20);
-            this.spdResetFilter.TabIndex = 102;
-            this.spdResetFilter.Text = "Reset";
-            this.spdResetFilter.UseVisualStyleBackColor = true;
-            this.spdResetFilter.Click += new System.EventHandler(this.SpdResetFilter_Click);
-            // 
-            // speResetFilter
-            // 
-            this.speResetFilter.Location = new System.Drawing.Point(649, 136);
-            this.speResetFilter.Name = "speResetFilter";
-            this.speResetFilter.Size = new System.Drawing.Size(43, 20);
-            this.speResetFilter.TabIndex = 103;
-            this.speResetFilter.Text = "Reset";
-            this.speResetFilter.UseVisualStyleBackColor = true;
-            this.speResetFilter.Click += new System.EventHandler(this.SpeResetFilter_Click);
-            // 
             // hpJudgeFilter
             // 
             this.hpJudgeFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
@@ -1483,7 +1417,7 @@ namespace SWSH_OWRNG_Generator_GUI
             "Best"});
             this.hpJudgeFilter.Location = new System.Drawing.Point(506, 4);
             this.hpJudgeFilter.Name = "hpJudgeFilter";
-            this.hpJudgeFilter.Size = new System.Drawing.Size(121, 21);
+            this.hpJudgeFilter.Size = new System.Drawing.Size(82, 21);
             this.hpJudgeFilter.TabIndex = 104;
             this.hpJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.HpJudgeFilter_SelectedIndexChanged);
             // 
@@ -1500,7 +1434,7 @@ namespace SWSH_OWRNG_Generator_GUI
             "Best"});
             this.atkJudgeFilter.Location = new System.Drawing.Point(506, 31);
             this.atkJudgeFilter.Name = "atkJudgeFilter";
-            this.atkJudgeFilter.Size = new System.Drawing.Size(121, 21);
+            this.atkJudgeFilter.Size = new System.Drawing.Size(82, 21);
             this.atkJudgeFilter.TabIndex = 105;
             this.atkJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.AtkJudgeFilter_SelectedIndexChanged);
             // 
@@ -1517,9 +1451,9 @@ namespace SWSH_OWRNG_Generator_GUI
             "Best"});
             this.defJudgeFilter.Location = new System.Drawing.Point(506, 57);
             this.defJudgeFilter.Name = "defJudgeFilter";
-            this.defJudgeFilter.Size = new System.Drawing.Size(121, 21);
+            this.defJudgeFilter.Size = new System.Drawing.Size(82, 21);
             this.defJudgeFilter.TabIndex = 106;
-            this.defJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.defJudgeFilter_SelectedIndexChanged);
+            this.defJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.DefJudgeFilter_SelectedIndexChanged);
             // 
             // spaJudgeFilter
             // 
@@ -1534,9 +1468,9 @@ namespace SWSH_OWRNG_Generator_GUI
             "Best"});
             this.spaJudgeFilter.Location = new System.Drawing.Point(506, 82);
             this.spaJudgeFilter.Name = "spaJudgeFilter";
-            this.spaJudgeFilter.Size = new System.Drawing.Size(121, 21);
+            this.spaJudgeFilter.Size = new System.Drawing.Size(82, 21);
             this.spaJudgeFilter.TabIndex = 107;
-            this.spaJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.spaJudgeFilter_SelectedIndexChanged);
+            this.spaJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.SpaJudgeFilter_SelectedIndexChanged);
             // 
             // spdJudgeFilter
             // 
@@ -1551,9 +1485,9 @@ namespace SWSH_OWRNG_Generator_GUI
             "Best"});
             this.spdJudgeFilter.Location = new System.Drawing.Point(506, 109);
             this.spdJudgeFilter.Name = "spdJudgeFilter";
-            this.spdJudgeFilter.Size = new System.Drawing.Size(121, 21);
+            this.spdJudgeFilter.Size = new System.Drawing.Size(82, 21);
             this.spdJudgeFilter.TabIndex = 108;
-            this.spdJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.spdJudgeFilter_SelectedIndexChanged);
+            this.spdJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.SpdJudgeFilter_SelectedIndexChanged);
             // 
             // speJudgeFilter
             // 
@@ -1568,26 +1502,20 @@ namespace SWSH_OWRNG_Generator_GUI
             "Best"});
             this.speJudgeFilter.Location = new System.Drawing.Point(506, 135);
             this.speJudgeFilter.Name = "speJudgeFilter";
-            this.speJudgeFilter.Size = new System.Drawing.Size(121, 21);
+            this.speJudgeFilter.Size = new System.Drawing.Size(82, 21);
             this.speJudgeFilter.TabIndex = 109;
-            this.speJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.speJudgeFilter_SelectedIndexChanged);
+            this.speJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.SpeJudgeFilter_SelectedIndexChanged);
             // 
             // MainWindow
             // 
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(977, 559);
+            this.ClientSize = new System.Drawing.Size(831, 559);
             this.Controls.Add(this.speJudgeFilter);
             this.Controls.Add(this.spdJudgeFilter);
             this.Controls.Add(this.spaJudgeFilter);
             this.Controls.Add(this.defJudgeFilter);
             this.Controls.Add(this.atkJudgeFilter);
             this.Controls.Add(this.hpJudgeFilter);
-            this.Controls.Add(this.speResetFilter);
-            this.Controls.Add(this.spdResetFilter);
-            this.Controls.Add(this.spaResetFilter);
-            this.Controls.Add(this.defResetFilter);
-            this.Controls.Add(this.atkResetFilter);
-            this.Controls.Add(this.hpResetFilter);
             this.Controls.Add(this.CheckCuteCharm);
             this.Controls.Add(this.sensBox);
             this.Controls.Add(this.CheckTIDSIDFinder);
@@ -1814,12 +1742,6 @@ namespace SWSH_OWRNG_Generator_GUI
         private System.Windows.Forms.DataGridViewTextBoxColumn Mark;
         private System.Windows.Forms.DataGridViewTextBoxColumn State0;
         private System.Windows.Forms.DataGridViewTextBoxColumn State1;
-        private System.Windows.Forms.Button hpResetFilter;
-        private System.Windows.Forms.Button atkResetFilter;
-        private System.Windows.Forms.Button defResetFilter;
-        private System.Windows.Forms.Button spaResetFilter;
-        private System.Windows.Forms.Button spdResetFilter;
-        private System.Windows.Forms.Button speResetFilter;
         private System.Windows.Forms.ComboBox hpJudgeFilter;
         private System.Windows.Forms.ComboBox atkJudgeFilter;
         private System.Windows.Forms.ComboBox defJudgeFilter;

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
@@ -73,6 +73,28 @@ namespace SWSH_OWRNG_Generator_GUI
             this.SelectedShiny = new System.Windows.Forms.ComboBox();
             this.LabelShiny = new System.Windows.Forms.Label();
             this.Results = new System.Windows.Forms.DataGridView();
+            this.Frame = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.TID = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.SID = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Animation = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Brilliant = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Level = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Slot = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.PID = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.EC = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Shiny = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Ability = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Nature = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Gender = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.HP = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Atk = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Def = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.SpA = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.SpD = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Spe = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.Mark = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.State0 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.State1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.generatorBindingSource = new System.Windows.Forms.BindingSource(this.components);
             this.label12 = new System.Windows.Forms.Label();
             this.speMinFilter = new System.Windows.Forms.Button();
@@ -127,28 +149,12 @@ namespace SWSH_OWRNG_Generator_GUI
             this.InputFlawlessIVs = new System.Windows.Forms.TextBox();
             this.sensBox = new System.Windows.Forms.CheckBox();
             this.CheckCuteCharm = new System.Windows.Forms.CheckBox();
-            this.Frame = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.TID = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.SID = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Animation = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Brilliant = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Level = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Slot = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.PID = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.EC = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Shiny = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Ability = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Nature = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Gender = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.HP = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Atk = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Def = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.SpA = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.SpD = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Spe = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.Mark = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.State0 = new System.Windows.Forms.DataGridViewTextBoxColumn();
-            this.State1 = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.hpResetFilter = new System.Windows.Forms.Button();
+            this.atkResetFilter = new System.Windows.Forms.Button();
+            this.defResetFilter = new System.Windows.Forms.Button();
+            this.spaResetFilter = new System.Windows.Forms.Button();
+            this.spdResetFilter = new System.Windows.Forms.Button();
+            this.speResetFilter = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.ImageRareMark)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.Results)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.generatorBindingSource)).BeginInit();
@@ -652,8 +658,216 @@ namespace SWSH_OWRNG_Generator_GUI
             this.Results.Name = "Results";
             this.Results.ReadOnly = true;
             this.Results.RowHeadersWidth = 62;
-            this.Results.Size = new System.Drawing.Size(746, 187);
+            this.Results.Size = new System.Drawing.Size(954, 166);
             this.Results.TabIndex = 73;
+            // 
+            // Frame
+            // 
+            this.Frame.DataPropertyName = "Advances";
+            this.Frame.HeaderText = "Frame";
+            this.Frame.MinimumWidth = 8;
+            this.Frame.Name = "Frame";
+            this.Frame.ReadOnly = true;
+            this.Frame.Width = 150;
+            // 
+            // TID
+            // 
+            this.TID.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.TID.DataPropertyName = "TID";
+            this.TID.HeaderText = "TID";
+            this.TID.MinimumWidth = 8;
+            this.TID.Name = "TID";
+            this.TID.ReadOnly = true;
+            this.TID.Width = 50;
+            // 
+            // SID
+            // 
+            this.SID.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.SID.DataPropertyName = "SID";
+            this.SID.HeaderText = "SID";
+            this.SID.MinimumWidth = 8;
+            this.SID.Name = "SID";
+            this.SID.ReadOnly = true;
+            this.SID.Width = 50;
+            // 
+            // Animation
+            // 
+            this.Animation.DataPropertyName = "Animation";
+            this.Animation.HeaderText = "Animation";
+            this.Animation.MinimumWidth = 8;
+            this.Animation.Name = "Animation";
+            this.Animation.ReadOnly = true;
+            this.Animation.Width = 60;
+            // 
+            // Brilliant
+            // 
+            this.Brilliant.DataPropertyName = "Brilliant";
+            this.Brilliant.HeaderText = "Brilliant";
+            this.Brilliant.Name = "Brilliant";
+            this.Brilliant.ReadOnly = true;
+            // 
+            // Level
+            // 
+            this.Level.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.Level.DataPropertyName = "Level";
+            this.Level.HeaderText = "Level";
+            this.Level.MinimumWidth = 8;
+            this.Level.Name = "Level";
+            this.Level.ReadOnly = true;
+            this.Level.Width = 58;
+            // 
+            // Slot
+            // 
+            this.Slot.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
+            this.Slot.DataPropertyName = "Slot";
+            this.Slot.HeaderText = "Slot";
+            this.Slot.MinimumWidth = 8;
+            this.Slot.Name = "Slot";
+            this.Slot.ReadOnly = true;
+            this.Slot.Width = 50;
+            // 
+            // PID
+            // 
+            this.PID.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.PID.DataPropertyName = "PID";
+            this.PID.HeaderText = "PID";
+            this.PID.MinimumWidth = 8;
+            this.PID.Name = "PID";
+            this.PID.ReadOnly = true;
+            this.PID.Width = 50;
+            // 
+            // EC
+            // 
+            this.EC.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.EC.DataPropertyName = "EC";
+            this.EC.HeaderText = "EC";
+            this.EC.MinimumWidth = 8;
+            this.EC.Name = "EC";
+            this.EC.ReadOnly = true;
+            this.EC.Width = 46;
+            // 
+            // Shiny
+            // 
+            this.Shiny.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.Shiny.DataPropertyName = "Shiny";
+            this.Shiny.HeaderText = "Shiny";
+            this.Shiny.MinimumWidth = 8;
+            this.Shiny.Name = "Shiny";
+            this.Shiny.ReadOnly = true;
+            this.Shiny.Width = 58;
+            // 
+            // Ability
+            // 
+            this.Ability.DataPropertyName = "Ability";
+            this.Ability.HeaderText = "Ability";
+            this.Ability.MinimumWidth = 8;
+            this.Ability.Name = "Ability";
+            this.Ability.ReadOnly = true;
+            this.Ability.Width = 50;
+            // 
+            // Nature
+            // 
+            this.Nature.DataPropertyName = "Nature";
+            this.Nature.HeaderText = "Nature";
+            this.Nature.MinimumWidth = 8;
+            this.Nature.Name = "Nature";
+            this.Nature.ReadOnly = true;
+            this.Nature.Width = 75;
+            // 
+            // Gender
+            // 
+            this.Gender.DataPropertyName = "Gender";
+            this.Gender.HeaderText = "Gender";
+            this.Gender.Name = "Gender";
+            this.Gender.ReadOnly = true;
+            // 
+            // HP
+            // 
+            this.HP.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.HP.DataPropertyName = "HP";
+            this.HP.HeaderText = "HP";
+            this.HP.MinimumWidth = 8;
+            this.HP.Name = "HP";
+            this.HP.ReadOnly = true;
+            this.HP.Width = 34;
+            // 
+            // Atk
+            // 
+            this.Atk.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.Atk.DataPropertyName = "Atk";
+            this.Atk.HeaderText = "Atk";
+            this.Atk.MinimumWidth = 8;
+            this.Atk.Name = "Atk";
+            this.Atk.ReadOnly = true;
+            this.Atk.Width = 34;
+            // 
+            // Def
+            // 
+            this.Def.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.Def.DataPropertyName = "Def";
+            this.Def.HeaderText = "Def";
+            this.Def.MinimumWidth = 8;
+            this.Def.Name = "Def";
+            this.Def.ReadOnly = true;
+            this.Def.Width = 34;
+            // 
+            // SpA
+            // 
+            this.SpA.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.SpA.DataPropertyName = "SpA";
+            this.SpA.HeaderText = "SpA";
+            this.SpA.MinimumWidth = 8;
+            this.SpA.Name = "SpA";
+            this.SpA.ReadOnly = true;
+            this.SpA.Width = 34;
+            // 
+            // SpD
+            // 
+            this.SpD.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.SpD.DataPropertyName = "SpD";
+            this.SpD.HeaderText = "SpD";
+            this.SpD.MinimumWidth = 8;
+            this.SpD.Name = "SpD";
+            this.SpD.ReadOnly = true;
+            this.SpD.Width = 34;
+            // 
+            // Spe
+            // 
+            this.Spe.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
+            this.Spe.DataPropertyName = "Spe";
+            this.Spe.HeaderText = "Spe";
+            this.Spe.MinimumWidth = 8;
+            this.Spe.Name = "Spe";
+            this.Spe.ReadOnly = true;
+            this.Spe.Width = 34;
+            // 
+            // Mark
+            // 
+            this.Mark.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
+            this.Mark.DataPropertyName = "Mark";
+            this.Mark.HeaderText = "Mark";
+            this.Mark.MinimumWidth = 8;
+            this.Mark.Name = "Mark";
+            this.Mark.ReadOnly = true;
+            this.Mark.Width = 56;
+            // 
+            // State0
+            // 
+            this.State0.DataPropertyName = "State0";
+            this.State0.HeaderText = "State0";
+            this.State0.MinimumWidth = 8;
+            this.State0.Name = "State0";
+            this.State0.ReadOnly = true;
+            this.State0.Width = 150;
+            // 
+            // State1
+            // 
+            this.State1.DataPropertyName = "State1";
+            this.State1.HeaderText = "State1";
+            this.State1.MinimumWidth = 8;
+            this.State1.Name = "State1";
+            this.State1.ReadOnly = true;
+            this.State1.Width = 150;
             // 
             // label12
             // 
@@ -1190,218 +1404,76 @@ namespace SWSH_OWRNG_Generator_GUI
             this.CheckCuteCharm.Text = "Cute Charm Lead";
             this.CheckCuteCharm.UseVisualStyleBackColor = true;
             // 
-            // Frame
+            // hpResetFilter
             // 
-            this.Frame.DataPropertyName = "Advances";
-            this.Frame.HeaderText = "Frame";
-            this.Frame.MinimumWidth = 8;
-            this.Frame.Name = "Frame";
-            this.Frame.ReadOnly = true;
-            this.Frame.Width = 150;
+            this.hpResetFilter.Location = new System.Drawing.Point(506, 5);
+            this.hpResetFilter.Name = "hpResetFilter";
+            this.hpResetFilter.Size = new System.Drawing.Size(43, 20);
+            this.hpResetFilter.TabIndex = 98;
+            this.hpResetFilter.Text = "Reset";
+            this.hpResetFilter.UseVisualStyleBackColor = true;
+            this.hpResetFilter.Click += new System.EventHandler(this.HpResetFilter_Click);
             // 
-            // TID
+            // atkResetFilter
             // 
-            this.TID.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.TID.DataPropertyName = "TID";
-            this.TID.HeaderText = "TID";
-            this.TID.MinimumWidth = 8;
-            this.TID.Name = "TID";
-            this.TID.ReadOnly = true;
-            this.TID.Width = 50;
+            this.atkResetFilter.Location = new System.Drawing.Point(506, 32);
+            this.atkResetFilter.Name = "atkResetFilter";
+            this.atkResetFilter.Size = new System.Drawing.Size(43, 20);
+            this.atkResetFilter.TabIndex = 99;
+            this.atkResetFilter.Text = "Reset";
+            this.atkResetFilter.UseVisualStyleBackColor = true;
+            this.atkResetFilter.Click += new System.EventHandler(this.AtkResetFilter_Click);
             // 
-            // SID
+            // defResetFilter
             // 
-            this.SID.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.SID.DataPropertyName = "SID";
-            this.SID.HeaderText = "SID";
-            this.SID.MinimumWidth = 8;
-            this.SID.Name = "SID";
-            this.SID.ReadOnly = true;
-            this.SID.Width = 50;
+            this.defResetFilter.Location = new System.Drawing.Point(506, 58);
+            this.defResetFilter.Name = "defResetFilter";
+            this.defResetFilter.Size = new System.Drawing.Size(43, 20);
+            this.defResetFilter.TabIndex = 100;
+            this.defResetFilter.Text = "Reset";
+            this.defResetFilter.UseVisualStyleBackColor = true;
+            this.defResetFilter.Click += new System.EventHandler(this.DefResetFilter_Click);
             // 
-            // Animation
+            // spaResetFilter
             // 
-            this.Animation.DataPropertyName = "Animation";
-            this.Animation.HeaderText = "Animation";
-            this.Animation.MinimumWidth = 8;
-            this.Animation.Name = "Animation";
-            this.Animation.ReadOnly = true;
-            this.Animation.Width = 60;
+            this.spaResetFilter.Location = new System.Drawing.Point(506, 84);
+            this.spaResetFilter.Name = "spaResetFilter";
+            this.spaResetFilter.Size = new System.Drawing.Size(43, 20);
+            this.spaResetFilter.TabIndex = 101;
+            this.spaResetFilter.Text = "Reset";
+            this.spaResetFilter.UseVisualStyleBackColor = true;
+            this.spaResetFilter.Click += new System.EventHandler(this.SpaResetFilter_Click);
             // 
-            // Brilliant
+            // spdResetFilter
             // 
-            this.Brilliant.DataPropertyName = "Brilliant";
-            this.Brilliant.HeaderText = "Brilliant";
-            this.Brilliant.Name = "Brilliant";
-            this.Brilliant.ReadOnly = true;
+            this.spdResetFilter.Location = new System.Drawing.Point(506, 110);
+            this.spdResetFilter.Name = "spdResetFilter";
+            this.spdResetFilter.Size = new System.Drawing.Size(43, 20);
+            this.spdResetFilter.TabIndex = 102;
+            this.spdResetFilter.Text = "Reset";
+            this.spdResetFilter.UseVisualStyleBackColor = true;
+            this.spdResetFilter.Click += new System.EventHandler(this.SpdResetFilter_Click);
             // 
-            // Level
+            // speResetFilter
             // 
-            this.Level.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.Level.DataPropertyName = "Level";
-            this.Level.HeaderText = "Level";
-            this.Level.MinimumWidth = 8;
-            this.Level.Name = "Level";
-            this.Level.ReadOnly = true;
-            this.Level.Width = 58;
-            // 
-            // Slot
-            // 
-            this.Slot.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.ColumnHeader;
-            this.Slot.DataPropertyName = "Slot";
-            this.Slot.HeaderText = "Slot";
-            this.Slot.MinimumWidth = 8;
-            this.Slot.Name = "Slot";
-            this.Slot.ReadOnly = true;
-            this.Slot.Width = 50;
-            // 
-            // PID
-            // 
-            this.PID.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.PID.DataPropertyName = "PID";
-            this.PID.HeaderText = "PID";
-            this.PID.MinimumWidth = 8;
-            this.PID.Name = "PID";
-            this.PID.ReadOnly = true;
-            this.PID.Width = 50;
-            // 
-            // EC
-            // 
-            this.EC.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.EC.DataPropertyName = "EC";
-            this.EC.HeaderText = "EC";
-            this.EC.MinimumWidth = 8;
-            this.EC.Name = "EC";
-            this.EC.ReadOnly = true;
-            this.EC.Width = 46;
-            // 
-            // Shiny
-            // 
-            this.Shiny.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.Shiny.DataPropertyName = "Shiny";
-            this.Shiny.HeaderText = "Shiny";
-            this.Shiny.MinimumWidth = 8;
-            this.Shiny.Name = "Shiny";
-            this.Shiny.ReadOnly = true;
-            this.Shiny.Width = 58;
-            // 
-            // Ability
-            // 
-            this.Ability.DataPropertyName = "Ability";
-            this.Ability.HeaderText = "Ability";
-            this.Ability.MinimumWidth = 8;
-            this.Ability.Name = "Ability";
-            this.Ability.ReadOnly = true;
-            this.Ability.Width = 50;
-            // 
-            // Nature
-            // 
-            this.Nature.DataPropertyName = "Nature";
-            this.Nature.HeaderText = "Nature";
-            this.Nature.MinimumWidth = 8;
-            this.Nature.Name = "Nature";
-            this.Nature.ReadOnly = true;
-            this.Nature.Width = 75;
-            // 
-            // Gender
-            // 
-            this.Gender.DataPropertyName = "Gender";
-            this.Gender.HeaderText = "Gender";
-            this.Gender.Name = "Gender";
-            this.Gender.ReadOnly = true;
-            // 
-            // HP
-            // 
-            this.HP.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.HP.DataPropertyName = "HP";
-            this.HP.HeaderText = "HP";
-            this.HP.MinimumWidth = 8;
-            this.HP.Name = "HP";
-            this.HP.ReadOnly = true;
-            this.HP.Width = 34;
-            // 
-            // Atk
-            // 
-            this.Atk.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.Atk.DataPropertyName = "Atk";
-            this.Atk.HeaderText = "Atk";
-            this.Atk.MinimumWidth = 8;
-            this.Atk.Name = "Atk";
-            this.Atk.ReadOnly = true;
-            this.Atk.Width = 34;
-            // 
-            // Def
-            // 
-            this.Def.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.Def.DataPropertyName = "Def";
-            this.Def.HeaderText = "Def";
-            this.Def.MinimumWidth = 8;
-            this.Def.Name = "Def";
-            this.Def.ReadOnly = true;
-            this.Def.Width = 34;
-            // 
-            // SpA
-            // 
-            this.SpA.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.SpA.DataPropertyName = "SpA";
-            this.SpA.HeaderText = "SpA";
-            this.SpA.MinimumWidth = 8;
-            this.SpA.Name = "SpA";
-            this.SpA.ReadOnly = true;
-            this.SpA.Width = 34;
-            // 
-            // SpD
-            // 
-            this.SpD.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.SpD.DataPropertyName = "SpD";
-            this.SpD.HeaderText = "SpD";
-            this.SpD.MinimumWidth = 8;
-            this.SpD.Name = "SpD";
-            this.SpD.ReadOnly = true;
-            this.SpD.Width = 34;
-            // 
-            // Spe
-            // 
-            this.Spe.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.None;
-            this.Spe.DataPropertyName = "Spe";
-            this.Spe.HeaderText = "Spe";
-            this.Spe.MinimumWidth = 8;
-            this.Spe.Name = "Spe";
-            this.Spe.ReadOnly = true;
-            this.Spe.Width = 34;
-            // 
-            // Mark
-            // 
-            this.Mark.AutoSizeMode = System.Windows.Forms.DataGridViewAutoSizeColumnMode.AllCells;
-            this.Mark.DataPropertyName = "Mark";
-            this.Mark.HeaderText = "Mark";
-            this.Mark.MinimumWidth = 8;
-            this.Mark.Name = "Mark";
-            this.Mark.ReadOnly = true;
-            this.Mark.Width = 56;
-            // 
-            // State0
-            // 
-            this.State0.DataPropertyName = "State0";
-            this.State0.HeaderText = "State0";
-            this.State0.MinimumWidth = 8;
-            this.State0.Name = "State0";
-            this.State0.ReadOnly = true;
-            this.State0.Width = 150;
-            // 
-            // State1
-            // 
-            this.State1.DataPropertyName = "State1";
-            this.State1.HeaderText = "State1";
-            this.State1.MinimumWidth = 8;
-            this.State1.Name = "State1";
-            this.State1.ReadOnly = true;
-            this.State1.Width = 150;
+            this.speResetFilter.Location = new System.Drawing.Point(506, 136);
+            this.speResetFilter.Name = "speResetFilter";
+            this.speResetFilter.Size = new System.Drawing.Size(43, 20);
+            this.speResetFilter.TabIndex = 103;
+            this.speResetFilter.Text = "Reset";
+            this.speResetFilter.UseVisualStyleBackColor = true;
+            this.speResetFilter.Click += new System.EventHandler(this.SpeResetFilter_Click);
             // 
             // MainWindow
             // 
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(769, 580);
+            this.ClientSize = new System.Drawing.Size(977, 559);
+            this.Controls.Add(this.speResetFilter);
+            this.Controls.Add(this.spdResetFilter);
+            this.Controls.Add(this.spaResetFilter);
+            this.Controls.Add(this.defResetFilter);
+            this.Controls.Add(this.atkResetFilter);
+            this.Controls.Add(this.hpResetFilter);
             this.Controls.Add(this.CheckCuteCharm);
             this.Controls.Add(this.sensBox);
             this.Controls.Add(this.CheckTIDSIDFinder);
@@ -1628,5 +1700,11 @@ namespace SWSH_OWRNG_Generator_GUI
         private System.Windows.Forms.DataGridViewTextBoxColumn Mark;
         private System.Windows.Forms.DataGridViewTextBoxColumn State0;
         private System.Windows.Forms.DataGridViewTextBoxColumn State1;
+        private System.Windows.Forms.Button hpResetFilter;
+        private System.Windows.Forms.Button atkResetFilter;
+        private System.Windows.Forms.Button defResetFilter;
+        private System.Windows.Forms.Button spaResetFilter;
+        private System.Windows.Forms.Button spdResetFilter;
+        private System.Windows.Forms.Button speResetFilter;
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
@@ -156,6 +156,7 @@ namespace SWSH_OWRNG_Generator_GUI
             this.spdResetFilter = new System.Windows.Forms.Button();
             this.speResetFilter = new System.Windows.Forms.Button();
             this.hpJudgeFilter = new System.Windows.Forms.ComboBox();
+            this.atkJudgeFilter = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.ImageRareMark)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.Results)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.generatorBindingSource)).BeginInit();
@@ -1482,10 +1483,28 @@ namespace SWSH_OWRNG_Generator_GUI
             this.hpJudgeFilter.TabIndex = 104;
             this.hpJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.HpJudgeFilter_SelectedIndexChanged);
             // 
+            // atkJudgeFilter
+            // 
+            this.atkJudgeFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.atkJudgeFilter.FormattingEnabled = true;
+            this.atkJudgeFilter.Items.AddRange(new object[] {
+            "No Good",
+            "Decent",
+            "Pretty Good",
+            "Very Good",
+            "Fantastic",
+            "Best"});
+            this.atkJudgeFilter.Location = new System.Drawing.Point(506, 31);
+            this.atkJudgeFilter.Name = "atkJudgeFilter";
+            this.atkJudgeFilter.Size = new System.Drawing.Size(121, 21);
+            this.atkJudgeFilter.TabIndex = 105;
+            this.atkJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.atkJudgeFilter_SelectedIndexChanged);
+            // 
             // MainWindow
             // 
             this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(977, 559);
+            this.Controls.Add(this.atkJudgeFilter);
             this.Controls.Add(this.hpJudgeFilter);
             this.Controls.Add(this.speResetFilter);
             this.Controls.Add(this.spdResetFilter);
@@ -1726,5 +1745,6 @@ namespace SWSH_OWRNG_Generator_GUI
         private System.Windows.Forms.Button spdResetFilter;
         private System.Windows.Forms.Button speResetFilter;
         private System.Windows.Forms.ComboBox hpJudgeFilter;
+        private System.Windows.Forms.ComboBox atkJudgeFilter;
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
@@ -1421,7 +1421,7 @@ namespace SWSH_OWRNG_Generator_GUI
             this.hpJudgeFilter.Name = "hpJudgeFilter";
             this.hpJudgeFilter.Size = new System.Drawing.Size(82, 21);
             this.hpJudgeFilter.TabIndex = 104;
-            this.hpJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.HpJudgeFilter_SelectedIndexChanged);
+            this.hpJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.JudgeFilter_SelectedIndexChanged);
             // 
             // atkJudgeFilter
             // 
@@ -1438,7 +1438,7 @@ namespace SWSH_OWRNG_Generator_GUI
             this.atkJudgeFilter.Name = "atkJudgeFilter";
             this.atkJudgeFilter.Size = new System.Drawing.Size(82, 21);
             this.atkJudgeFilter.TabIndex = 105;
-            this.atkJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.AtkJudgeFilter_SelectedIndexChanged);
+            this.atkJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.JudgeFilter_SelectedIndexChanged);
             // 
             // defJudgeFilter
             // 
@@ -1455,7 +1455,7 @@ namespace SWSH_OWRNG_Generator_GUI
             this.defJudgeFilter.Name = "defJudgeFilter";
             this.defJudgeFilter.Size = new System.Drawing.Size(82, 21);
             this.defJudgeFilter.TabIndex = 106;
-            this.defJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.DefJudgeFilter_SelectedIndexChanged);
+            this.defJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.JudgeFilter_SelectedIndexChanged);
             // 
             // spaJudgeFilter
             // 
@@ -1472,7 +1472,7 @@ namespace SWSH_OWRNG_Generator_GUI
             this.spaJudgeFilter.Name = "spaJudgeFilter";
             this.spaJudgeFilter.Size = new System.Drawing.Size(82, 21);
             this.spaJudgeFilter.TabIndex = 107;
-            this.spaJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.SpaJudgeFilter_SelectedIndexChanged);
+            this.spaJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.JudgeFilter_SelectedIndexChanged);
             // 
             // spdJudgeFilter
             // 
@@ -1489,7 +1489,7 @@ namespace SWSH_OWRNG_Generator_GUI
             this.spdJudgeFilter.Name = "spdJudgeFilter";
             this.spdJudgeFilter.Size = new System.Drawing.Size(82, 21);
             this.spdJudgeFilter.TabIndex = 108;
-            this.spdJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.SpdJudgeFilter_SelectedIndexChanged);
+            this.spdJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.JudgeFilter_SelectedIndexChanged);
             // 
             // speJudgeFilter
             // 
@@ -1506,7 +1506,7 @@ namespace SWSH_OWRNG_Generator_GUI
             this.speJudgeFilter.Name = "speJudgeFilter";
             this.speJudgeFilter.Size = new System.Drawing.Size(82, 21);
             this.speJudgeFilter.TabIndex = 109;
-            this.speJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.SpeJudgeFilter_SelectedIndexChanged);
+            this.speJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.JudgeFilter_SelectedIndexChanged);
             // 
             // DesiredNature
             // 

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
@@ -155,6 +155,7 @@ namespace SWSH_OWRNG_Generator_GUI
             this.spaResetFilter = new System.Windows.Forms.Button();
             this.spdResetFilter = new System.Windows.Forms.Button();
             this.speResetFilter = new System.Windows.Forms.Button();
+            this.hpJudgeFilter = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.ImageRareMark)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.Results)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.generatorBindingSource)).BeginInit();
@@ -1146,7 +1147,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             this.RetailAdvancesTrackerLabel.AutoSize = true;
             this.RetailAdvancesTrackerLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.RetailAdvancesTrackerLabel.Location = new System.Drawing.Point(548, 9);
+            this.RetailAdvancesTrackerLabel.Location = new System.Drawing.Point(755, 24);
             this.RetailAdvancesTrackerLabel.Name = "RetailAdvancesTrackerLabel";
             this.RetailAdvancesTrackerLabel.Size = new System.Drawing.Size(148, 13);
             this.RetailAdvancesTrackerLabel.TabIndex = 75;
@@ -1155,7 +1156,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // RetailAdvancesTrackerInitialInputLabel
             // 
             this.RetailAdvancesTrackerInitialInputLabel.AutoSize = true;
-            this.RetailAdvancesTrackerInitialInputLabel.Location = new System.Drawing.Point(548, 35);
+            this.RetailAdvancesTrackerInitialInputLabel.Location = new System.Drawing.Point(755, 50);
             this.RetailAdvancesTrackerInitialInputLabel.Name = "RetailAdvancesTrackerInitialInputLabel";
             this.RetailAdvancesTrackerInitialInputLabel.Size = new System.Drawing.Size(59, 13);
             this.RetailAdvancesTrackerInitialInputLabel.TabIndex = 76;
@@ -1164,7 +1165,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // RetailAdvancesTrackerMaxAdvInputLabel
             // 
             this.RetailAdvancesTrackerMaxAdvInputLabel.AutoSize = true;
-            this.RetailAdvancesTrackerMaxAdvInputLabel.Location = new System.Drawing.Point(594, 61);
+            this.RetailAdvancesTrackerMaxAdvInputLabel.Location = new System.Drawing.Point(801, 76);
             this.RetailAdvancesTrackerMaxAdvInputLabel.Name = "RetailAdvancesTrackerMaxAdvInputLabel";
             this.RetailAdvancesTrackerMaxAdvInputLabel.Size = new System.Drawing.Size(13, 13);
             this.RetailAdvancesTrackerMaxAdvInputLabel.TabIndex = 77;
@@ -1172,7 +1173,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // RetailAdvancesTrackerInitialInput
             // 
-            this.RetailAdvancesTrackerInitialInput.Location = new System.Drawing.Point(613, 32);
+            this.RetailAdvancesTrackerInitialInput.Location = new System.Drawing.Point(820, 47);
             this.RetailAdvancesTrackerInitialInput.MaxLength = 16;
             this.RetailAdvancesTrackerInitialInput.Name = "RetailAdvancesTrackerInitialInput";
             this.RetailAdvancesTrackerInitialInput.Size = new System.Drawing.Size(145, 20);
@@ -1183,7 +1184,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // RetailAdvancesTrackerMaxInput
             // 
-            this.RetailAdvancesTrackerMaxInput.Location = new System.Drawing.Point(613, 58);
+            this.RetailAdvancesTrackerMaxInput.Location = new System.Drawing.Point(820, 73);
             this.RetailAdvancesTrackerMaxInput.MaxLength = 16;
             this.RetailAdvancesTrackerMaxInput.Name = "RetailAdvancesTrackerMaxInput";
             this.RetailAdvancesTrackerMaxInput.Size = new System.Drawing.Size(145, 20);
@@ -1194,7 +1195,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // RetailAdvancesTrackerGenerateButton
             // 
-            this.RetailAdvancesTrackerGenerateButton.Location = new System.Drawing.Point(551, 91);
+            this.RetailAdvancesTrackerGenerateButton.Location = new System.Drawing.Point(758, 106);
             this.RetailAdvancesTrackerGenerateButton.Name = "RetailAdvancesTrackerGenerateButton";
             this.RetailAdvancesTrackerGenerateButton.Size = new System.Drawing.Size(207, 20);
             this.RetailAdvancesTrackerGenerateButton.TabIndex = 80;
@@ -1205,14 +1206,14 @@ namespace SWSH_OWRNG_Generator_GUI
             // RetailAdvancesTrackerProgressBar
             // 
             this.RetailAdvancesTrackerProgressBar.ForeColor = System.Drawing.SystemColors.ActiveCaption;
-            this.RetailAdvancesTrackerProgressBar.Location = new System.Drawing.Point(552, 115);
+            this.RetailAdvancesTrackerProgressBar.Location = new System.Drawing.Point(759, 130);
             this.RetailAdvancesTrackerProgressBar.Name = "RetailAdvancesTrackerProgressBar";
             this.RetailAdvancesTrackerProgressBar.Size = new System.Drawing.Size(205, 10);
             this.RetailAdvancesTrackerProgressBar.TabIndex = 81;
             // 
             // RetailAdvancesTrackerSequenceInput
             // 
-            this.RetailAdvancesTrackerSequenceInput.Location = new System.Drawing.Point(551, 152);
+            this.RetailAdvancesTrackerSequenceInput.Location = new System.Drawing.Point(758, 167);
             this.RetailAdvancesTrackerSequenceInput.MaxLength = 30;
             this.RetailAdvancesTrackerSequenceInput.Name = "RetailAdvancesTrackerSequenceInput";
             this.RetailAdvancesTrackerSequenceInput.ReadOnly = true;
@@ -1224,7 +1225,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // RetailAdvancesTrackerSequenceLabel
             // 
             this.RetailAdvancesTrackerSequenceLabel.AutoSize = true;
-            this.RetailAdvancesTrackerSequenceLabel.Location = new System.Drawing.Point(548, 136);
+            this.RetailAdvancesTrackerSequenceLabel.Location = new System.Drawing.Point(755, 151);
             this.RetailAdvancesTrackerSequenceLabel.Name = "RetailAdvancesTrackerSequenceLabel";
             this.RetailAdvancesTrackerSequenceLabel.Size = new System.Drawing.Size(199, 13);
             this.RetailAdvancesTrackerSequenceLabel.TabIndex = 83;
@@ -1232,7 +1233,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // RetailAdvancesTrackerResultState0
             // 
-            this.RetailAdvancesTrackerResultState0.Location = new System.Drawing.Point(551, 237);
+            this.RetailAdvancesTrackerResultState0.Location = new System.Drawing.Point(758, 252);
             this.RetailAdvancesTrackerResultState0.MaxLength = 16;
             this.RetailAdvancesTrackerResultState0.Name = "RetailAdvancesTrackerResultState0";
             this.RetailAdvancesTrackerResultState0.ReadOnly = true;
@@ -1243,7 +1244,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(548, 264);
+            this.label3.Location = new System.Drawing.Point(755, 279);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(84, 13);
             this.label3.TabIndex = 87;
@@ -1251,7 +1252,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // RetailAdvancesTrackerResultState1
             // 
-            this.RetailAdvancesTrackerResultState1.Location = new System.Drawing.Point(551, 280);
+            this.RetailAdvancesTrackerResultState1.Location = new System.Drawing.Point(758, 295);
             this.RetailAdvancesTrackerResultState1.MaxLength = 16;
             this.RetailAdvancesTrackerResultState1.Name = "RetailAdvancesTrackerResultState1";
             this.RetailAdvancesTrackerResultState1.ReadOnly = true;
@@ -1262,7 +1263,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // label2
             // 
             this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(548, 221);
+            this.label2.Location = new System.Drawing.Point(755, 236);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(84, 13);
             this.label2.TabIndex = 85;
@@ -1271,7 +1272,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // RetailAdvancesTrackerNumResultsLabel
             // 
             this.RetailAdvancesTrackerNumResultsLabel.AutoSize = true;
-            this.RetailAdvancesTrackerNumResultsLabel.Location = new System.Drawing.Point(548, 189);
+            this.RetailAdvancesTrackerNumResultsLabel.Location = new System.Drawing.Point(755, 204);
             this.RetailAdvancesTrackerNumResultsLabel.Name = "RetailAdvancesTrackerNumResultsLabel";
             this.RetailAdvancesTrackerNumResultsLabel.Size = new System.Drawing.Size(110, 13);
             this.RetailAdvancesTrackerNumResultsLabel.TabIndex = 88;
@@ -1300,7 +1301,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // ButtonUpdateStates
             // 
-            this.ButtonUpdateStates.Location = new System.Drawing.Point(550, 306);
+            this.ButtonUpdateStates.Location = new System.Drawing.Point(757, 321);
             this.ButtonUpdateStates.Name = "ButtonUpdateStates";
             this.ButtonUpdateStates.Size = new System.Drawing.Size(209, 20);
             this.ButtonUpdateStates.TabIndex = 89;
@@ -1406,7 +1407,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // hpResetFilter
             // 
-            this.hpResetFilter.Location = new System.Drawing.Point(506, 5);
+            this.hpResetFilter.Location = new System.Drawing.Point(649, 5);
             this.hpResetFilter.Name = "hpResetFilter";
             this.hpResetFilter.Size = new System.Drawing.Size(43, 20);
             this.hpResetFilter.TabIndex = 98;
@@ -1416,7 +1417,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // atkResetFilter
             // 
-            this.atkResetFilter.Location = new System.Drawing.Point(506, 32);
+            this.atkResetFilter.Location = new System.Drawing.Point(649, 32);
             this.atkResetFilter.Name = "atkResetFilter";
             this.atkResetFilter.Size = new System.Drawing.Size(43, 20);
             this.atkResetFilter.TabIndex = 99;
@@ -1426,7 +1427,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // defResetFilter
             // 
-            this.defResetFilter.Location = new System.Drawing.Point(506, 58);
+            this.defResetFilter.Location = new System.Drawing.Point(649, 58);
             this.defResetFilter.Name = "defResetFilter";
             this.defResetFilter.Size = new System.Drawing.Size(43, 20);
             this.defResetFilter.TabIndex = 100;
@@ -1436,7 +1437,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // spaResetFilter
             // 
-            this.spaResetFilter.Location = new System.Drawing.Point(506, 84);
+            this.spaResetFilter.Location = new System.Drawing.Point(649, 84);
             this.spaResetFilter.Name = "spaResetFilter";
             this.spaResetFilter.Size = new System.Drawing.Size(43, 20);
             this.spaResetFilter.TabIndex = 101;
@@ -1446,7 +1447,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // spdResetFilter
             // 
-            this.spdResetFilter.Location = new System.Drawing.Point(506, 110);
+            this.spdResetFilter.Location = new System.Drawing.Point(649, 110);
             this.spdResetFilter.Name = "spdResetFilter";
             this.spdResetFilter.Size = new System.Drawing.Size(43, 20);
             this.spdResetFilter.TabIndex = 102;
@@ -1456,7 +1457,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // 
             // speResetFilter
             // 
-            this.speResetFilter.Location = new System.Drawing.Point(506, 136);
+            this.speResetFilter.Location = new System.Drawing.Point(649, 136);
             this.speResetFilter.Name = "speResetFilter";
             this.speResetFilter.Size = new System.Drawing.Size(43, 20);
             this.speResetFilter.TabIndex = 103;
@@ -1464,10 +1465,28 @@ namespace SWSH_OWRNG_Generator_GUI
             this.speResetFilter.UseVisualStyleBackColor = true;
             this.speResetFilter.Click += new System.EventHandler(this.SpeResetFilter_Click);
             // 
+            // hpJudgeFilter
+            // 
+            this.hpJudgeFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.hpJudgeFilter.FormattingEnabled = true;
+            this.hpJudgeFilter.Items.AddRange(new object[] {
+            "No Good",
+            "Decent",
+            "Pretty Good",
+            "Very Good",
+            "Fantastic",
+            "Best"});
+            this.hpJudgeFilter.Location = new System.Drawing.Point(506, 4);
+            this.hpJudgeFilter.Name = "hpJudgeFilter";
+            this.hpJudgeFilter.Size = new System.Drawing.Size(121, 21);
+            this.hpJudgeFilter.TabIndex = 104;
+            this.hpJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.HpJudgeFilter_SelectedIndexChanged);
+            // 
             // MainWindow
             // 
             this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(977, 559);
+            this.Controls.Add(this.hpJudgeFilter);
             this.Controls.Add(this.speResetFilter);
             this.Controls.Add(this.spdResetFilter);
             this.Controls.Add(this.spaResetFilter);
@@ -1706,5 +1725,6 @@ namespace SWSH_OWRNG_Generator_GUI
         private System.Windows.Forms.Button spaResetFilter;
         private System.Windows.Forms.Button spdResetFilter;
         private System.Windows.Forms.Button speResetFilter;
+        private System.Windows.Forms.ComboBox hpJudgeFilter;
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
@@ -155,6 +155,8 @@ namespace SWSH_OWRNG_Generator_GUI
             this.spaJudgeFilter = new System.Windows.Forms.ComboBox();
             this.spdJudgeFilter = new System.Windows.Forms.ComboBox();
             this.speJudgeFilter = new System.Windows.Forms.ComboBox();
+            this.DesiredNature = new System.Windows.Forms.Label();
+            this.SelectedNature = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.ImageRareMark)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.Results)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.generatorBindingSource)).BeginInit();
@@ -1386,7 +1388,7 @@ namespace SWSH_OWRNG_Generator_GUI
             // sensBox
             // 
             this.sensBox.AutoSize = true;
-            this.sensBox.Location = new System.Drawing.Point(319, 220);
+            this.sensBox.Location = new System.Drawing.Point(319, 252);
             this.sensBox.Name = "sensBox";
             this.sensBox.Size = new System.Drawing.Size(124, 17);
             this.sensBox.TabIndex = 96;
@@ -1506,10 +1508,57 @@ namespace SWSH_OWRNG_Generator_GUI
             this.speJudgeFilter.TabIndex = 109;
             this.speJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.SpeJudgeFilter_SelectedIndexChanged);
             // 
+            // DesiredNature
+            // 
+            this.DesiredNature.AutoSize = true;
+            this.DesiredNature.Location = new System.Drawing.Point(303, 219);
+            this.DesiredNature.Name = "DesiredNature";
+            this.DesiredNature.Size = new System.Drawing.Size(42, 13);
+            this.DesiredNature.TabIndex = 110;
+            this.DesiredNature.Text = "Nature:";
+            // 
+            // SelectedNature
+            // 
+            this.SelectedNature.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.SelectedNature.FormattingEnabled = true;
+            this.SelectedNature.Items.AddRange(new object[] {
+            "Ignore",
+            "Hardy",
+            "Lonely",
+            "Brave",
+            "Adamant",
+            "Naughty",
+            "Bold",
+            "Docile",
+            "Relaxed",
+            "Impish",
+            "Lax",
+            "Timid",
+            "Hasty",
+            "Serious",
+            "Jolly",
+            "Naive",
+            "Modest",
+            "Mild",
+            "Quiet",
+            "Bashful",
+            "Rash",
+            "Calm",
+            "Gentle",
+            "Sassy",
+            "Careful",
+            "Quirky"});
+            this.SelectedNature.Location = new System.Drawing.Point(353, 216);
+            this.SelectedNature.Name = "SelectedNature";
+            this.SelectedNature.Size = new System.Drawing.Size(147, 21);
+            this.SelectedNature.TabIndex = 111;
+            // 
             // MainWindow
             // 
             this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(831, 559);
+            this.Controls.Add(this.SelectedNature);
+            this.Controls.Add(this.DesiredNature);
             this.Controls.Add(this.speJudgeFilter);
             this.Controls.Add(this.spdJudgeFilter);
             this.Controls.Add(this.spaJudgeFilter);
@@ -1748,5 +1797,7 @@ namespace SWSH_OWRNG_Generator_GUI
         private System.Windows.Forms.ComboBox spaJudgeFilter;
         private System.Windows.Forms.ComboBox spdJudgeFilter;
         private System.Windows.Forms.ComboBox speJudgeFilter;
+        private System.Windows.Forms.Label DesiredNature;
+        private System.Windows.Forms.ComboBox SelectedNature;
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.Designer.cs
@@ -157,6 +157,10 @@ namespace SWSH_OWRNG_Generator_GUI
             this.speResetFilter = new System.Windows.Forms.Button();
             this.hpJudgeFilter = new System.Windows.Forms.ComboBox();
             this.atkJudgeFilter = new System.Windows.Forms.ComboBox();
+            this.defJudgeFilter = new System.Windows.Forms.ComboBox();
+            this.spaJudgeFilter = new System.Windows.Forms.ComboBox();
+            this.spdJudgeFilter = new System.Windows.Forms.ComboBox();
+            this.speJudgeFilter = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.ImageRareMark)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.Results)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.generatorBindingSource)).BeginInit();
@@ -1498,12 +1502,84 @@ namespace SWSH_OWRNG_Generator_GUI
             this.atkJudgeFilter.Name = "atkJudgeFilter";
             this.atkJudgeFilter.Size = new System.Drawing.Size(121, 21);
             this.atkJudgeFilter.TabIndex = 105;
-            this.atkJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.atkJudgeFilter_SelectedIndexChanged);
+            this.atkJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.AtkJudgeFilter_SelectedIndexChanged);
+            // 
+            // defJudgeFilter
+            // 
+            this.defJudgeFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.defJudgeFilter.FormattingEnabled = true;
+            this.defJudgeFilter.Items.AddRange(new object[] {
+            "No Good",
+            "Decent",
+            "Pretty Good",
+            "Very Good",
+            "Fantastic",
+            "Best"});
+            this.defJudgeFilter.Location = new System.Drawing.Point(506, 57);
+            this.defJudgeFilter.Name = "defJudgeFilter";
+            this.defJudgeFilter.Size = new System.Drawing.Size(121, 21);
+            this.defJudgeFilter.TabIndex = 106;
+            this.defJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.defJudgeFilter_SelectedIndexChanged);
+            // 
+            // spaJudgeFilter
+            // 
+            this.spaJudgeFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.spaJudgeFilter.FormattingEnabled = true;
+            this.spaJudgeFilter.Items.AddRange(new object[] {
+            "No Good",
+            "Decent",
+            "Pretty Good",
+            "Very Good",
+            "Fantastic",
+            "Best"});
+            this.spaJudgeFilter.Location = new System.Drawing.Point(506, 82);
+            this.spaJudgeFilter.Name = "spaJudgeFilter";
+            this.spaJudgeFilter.Size = new System.Drawing.Size(121, 21);
+            this.spaJudgeFilter.TabIndex = 107;
+            this.spaJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.spaJudgeFilter_SelectedIndexChanged);
+            // 
+            // spdJudgeFilter
+            // 
+            this.spdJudgeFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.spdJudgeFilter.FormattingEnabled = true;
+            this.spdJudgeFilter.Items.AddRange(new object[] {
+            "No Good",
+            "Decent",
+            "Pretty Good",
+            "Very Good",
+            "Fantastic",
+            "Best"});
+            this.spdJudgeFilter.Location = new System.Drawing.Point(506, 109);
+            this.spdJudgeFilter.Name = "spdJudgeFilter";
+            this.spdJudgeFilter.Size = new System.Drawing.Size(121, 21);
+            this.spdJudgeFilter.TabIndex = 108;
+            this.spdJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.spdJudgeFilter_SelectedIndexChanged);
+            // 
+            // speJudgeFilter
+            // 
+            this.speJudgeFilter.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.speJudgeFilter.FormattingEnabled = true;
+            this.speJudgeFilter.Items.AddRange(new object[] {
+            "No Good",
+            "Decent",
+            "Pretty Good",
+            "Very Good",
+            "Fantastic",
+            "Best"});
+            this.speJudgeFilter.Location = new System.Drawing.Point(506, 135);
+            this.speJudgeFilter.Name = "speJudgeFilter";
+            this.speJudgeFilter.Size = new System.Drawing.Size(121, 21);
+            this.speJudgeFilter.TabIndex = 109;
+            this.speJudgeFilter.SelectedIndexChanged += new System.EventHandler(this.speJudgeFilter_SelectedIndexChanged);
             // 
             // MainWindow
             // 
             this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(977, 559);
+            this.Controls.Add(this.speJudgeFilter);
+            this.Controls.Add(this.spdJudgeFilter);
+            this.Controls.Add(this.spaJudgeFilter);
+            this.Controls.Add(this.defJudgeFilter);
             this.Controls.Add(this.atkJudgeFilter);
             this.Controls.Add(this.hpJudgeFilter);
             this.Controls.Add(this.speResetFilter);
@@ -1746,5 +1822,9 @@ namespace SWSH_OWRNG_Generator_GUI
         private System.Windows.Forms.Button speResetFilter;
         private System.Windows.Forms.ComboBox hpJudgeFilter;
         private System.Windows.Forms.ComboBox atkJudgeFilter;
+        private System.Windows.Forms.ComboBox defJudgeFilter;
+        private System.Windows.Forms.ComboBox spaJudgeFilter;
+        private System.Windows.Forms.ComboBox spdJudgeFilter;
+        private System.Windows.Forms.ComboBox speJudgeFilter;
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -30,6 +30,7 @@ namespace SWSH_OWRNG_Generator_GUI
 
             SelectedMark.SelectedIndex = 0;
             SelectedShiny.SelectedIndex = 0;
+            SelectedNature.SelectedIndex = 0;
 
             // Set Tab Indexes Manually
             // This will make life easier when adding more fields later on
@@ -53,19 +54,26 @@ namespace SWSH_OWRNG_Generator_GUI
             speMax.TabIndex = speMin.TabIndex + 1;
             hpMinFilter.TabIndex = speMax.TabIndex + 1;
             hpMaxFilter.TabIndex = hpMinFilter.TabIndex + 1;
-            atkMinFilter.TabIndex = hpMaxFilter.TabIndex + 1;
+            hpJudgeFilter.TabIndex = hpMaxFilter.TabIndex + 1;
+            atkMinFilter.TabIndex = hpJudgeFilter.TabIndex + 1;
             atkMaxFilter.TabIndex = atkMinFilter.TabIndex + 1;
-            defMinFilter.TabIndex = atkMaxFilter.TabIndex + 1;
+            atkJudgeFilter.TabIndex = atkMaxFilter.TabIndex + 1;
+            defMinFilter.TabIndex = atkJudgeFilter.TabIndex + 1;
             defMaxFilter.TabIndex = defMinFilter.TabIndex + 1;
-            spaMinFilter.TabIndex = defMaxFilter.TabIndex + 1;
+            defJudgeFilter.TabIndex = defMaxFilter.TabIndex + 1;
+            spaMinFilter.TabIndex = defJudgeFilter.TabIndex + 1;
             spaMaxFilter.TabIndex = spaMinFilter.TabIndex + 1;
-            spdMinFilter.TabIndex = spaMaxFilter.TabIndex + 1;
+            spaJudgeFilter.TabIndex = spaMaxFilter.TabIndex + 1;
+            spdMinFilter.TabIndex = spaJudgeFilter.TabIndex + 1;
             spdMaxFilter.TabIndex = spdMinFilter.TabIndex + 1;
-            speMinFilter.TabIndex = spdMaxFilter.TabIndex + 1;
+            spdJudgeFilter.TabIndex = spdMaxFilter.TabIndex + 1;
+            speMinFilter.TabIndex = spdJudgeFilter.TabIndex + 1;
             speMaxFilter.TabIndex = speMinFilter.TabIndex + 1;
-            SelectedMark.TabIndex = speMaxFilter.TabIndex + 1;
+            speJudgeFilter.TabIndex = speMaxFilter.TabIndex + 1;
+            SelectedMark.TabIndex = speJudgeFilter.TabIndex + 1;
             SelectedShiny.TabIndex = SelectedMark.TabIndex + 1;
-            CheckShinyCharm.TabIndex = SelectedShiny.TabIndex + 1;
+            SelectedNature.TabIndex = SelectedShiny.TabIndex + 1;
+            CheckShinyCharm.TabIndex = SelectedNature.TabIndex + 1;
             CheckStatic.TabIndex = CheckShinyCharm.TabIndex + 1;
             CheckMarkCharm.TabIndex = CheckStatic.TabIndex + 1;
             CheckFishing.TabIndex = CheckMarkCharm.TabIndex + 1;
@@ -499,6 +507,7 @@ namespace SWSH_OWRNG_Generator_GUI
             bool IsCuteCharm = CheckCuteCharm.Checked;
             string DesiredMark = (string)SelectedMark.SelectedItem;
             string DesiredShiny = (string)SelectedShiny.SelectedItem;
+            string DesiredNature = (string)SelectedNature.SelectedItem;
             uint[] MinIVs = { UInt16.Parse(hpMin.Text), UInt16.Parse(atkMin.Text), UInt16.Parse(defMin.Text), UInt16.Parse(spaMin.Text), UInt16.Parse(spdMin.Text), UInt16.Parse(speMin.Text) };
             uint[] MaxIVs = { UInt16.Parse(hpMax.Text), UInt16.Parse(atkMax.Text), UInt16.Parse(defMax.Text), UInt16.Parse(spaMax.Text), UInt16.Parse(spdMax.Text), UInt16.Parse(speMax.Text) };
             int[] WrongIVs = new int[6];
@@ -546,7 +555,7 @@ namespace SWSH_OWRNG_Generator_GUI
             });
 
             List<Frame> Frames = await Task.Run(() => Generator.Generate(
-                s0, s1, advances, TID, SID, ShinyCharm, MarkCharm, Weather, Static, Fishing, HeldItem, DesiredMark, DesiredShiny,
+                s0, s1, advances, TID, SID, ShinyCharm, MarkCharm, Weather, Static, Fishing, HeldItem, DesiredMark, DesiredShiny,DesiredNature,
                 LevelMin, LevelMax, SlotMin, SlotMax, MinIVs, MaxIVs, IsAbilityLocked, EMCount, KOCount, FlawlessIVs, IsCuteCharm, 
                 TIDSIDSearch, progress
             ));

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -750,46 +750,33 @@ namespace SWSH_OWRNG_Generator_GUI
             switch (hpJudgeFilter.Text)
             {
                 case "No Good":
-                    hpMin.Clear();
-                    hpMin.Text = "0";
-                    hpMax.Clear();
-                    hpMax.Text = "0";
+                    SetFilterStats(hpMin, hpMax, "0", "0");
                     break;
                 case "Decent":
-                    hpMin.Clear();
-                    hpMin.Text = "1";
-                    hpMax.Clear();
-                    hpMax.Text = "15";
+                    SetFilterStats(hpMin, hpMax, "1", "15");
                     break;
                 case "Pretty Good":
-                    hpMin.Clear();
-                    hpMin.Text = "16";
-                    hpMax.Clear();
-                    hpMax.Text = "25";
+                    SetFilterStats(hpMin, hpMax, "16", "25");
                     break;
                 case "Very Good":
-                    hpMin.Clear();
-                    hpMin.Text = "26";
-                    hpMax.Clear();
-                    hpMax.Text = "29";
+                    SetFilterStats(hpMin, hpMax, "26", "29");
                     break;
                 case "Fantastic":
-                    hpMin.Clear();
-                    hpMin.Text = "30";
-                    hpMax.Clear();
-                    hpMax.Text = "30";
+                    SetFilterStats(hpMin, hpMax, "30", "30");
                     break;
                 case "Best":
-                    hpMin.Clear();
-                    hpMin.Text = "31";
-                    hpMax.Clear();
-                    hpMax.Text = "31";
+                    SetFilterStats(hpMin, hpMax, "31", "31");
                     break;
                 default:
                     break;
             }
         }
-
-
+        private void SetFilterStats(TextBox statLower, TextBox statUpper, string min, string max)
+        {
+            statLower.Clear();
+            statLower.Text = min;
+            statUpper.Clear();
+            statUpper.Text = max;
+        }
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -697,5 +697,54 @@ namespace SWSH_OWRNG_Generator_GUI
             }
             
         }
+
+        private void HpResetFilter_Click(object sender, EventArgs e)
+        {
+            hpMin.Clear();
+            hpMin.Text = "0";
+            hpMax.Clear();
+            hpMax.Text = "31";
+        }
+        private void AtkResetFilter_Click(object sender, EventArgs e)
+        {
+            atkMin.Clear();
+            atkMin.Text = "0";
+            atkMax.Clear();
+            atkMax.Text = "31";
+        }
+
+        private void DefResetFilter_Click(object sender, EventArgs e)
+        {
+            defMin.Clear();
+            defMin.Text = "0";
+            defMax.Clear();
+            defMax.Text = "31";
+        }
+
+        private void SpaResetFilter_Click(object sender, EventArgs e)
+        {
+            spaMin.Clear();
+            spaMin.Text = "0";
+            spaMax.Clear();
+            spaMax.Text = "31";
+        }
+
+        private void SpdResetFilter_Click(object sender, EventArgs e)
+        {
+            spdMin.Clear();
+            spdMin.Text = "0";
+            spdMax.Clear();
+            spdMax.Text = "31";
+        }
+
+        private void SpeResetFilter_Click(object sender, EventArgs e)
+        {
+            speMin.Clear();
+            speMin.Text = "0";
+            speMax.Clear();
+            speMax.Text = "31";
+        }
+
+        
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -747,29 +747,7 @@ namespace SWSH_OWRNG_Generator_GUI
 
         private void HpJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
         {
-            switch (hpJudgeFilter.Text)
-            {
-                case "No Good":
-                    SetFilterStats(hpMin, hpMax, "0", "0");
-                    break;
-                case "Decent":
-                    SetFilterStats(hpMin, hpMax, "1", "15");
-                    break;
-                case "Pretty Good":
-                    SetFilterStats(hpMin, hpMax, "16", "25");
-                    break;
-                case "Very Good":
-                    SetFilterStats(hpMin, hpMax, "26", "29");
-                    break;
-                case "Fantastic":
-                    SetFilterStats(hpMin, hpMax, "30", "30");
-                    break;
-                case "Best":
-                    SetFilterStats(hpMin, hpMax, "31", "31");
-                    break;
-                default:
-                    break;
-            }
+            StatJudgeFilter(hpMin, hpMax, hpJudgeFilter.Text);
         }
         private void SetFilterStats(TextBox statLower, TextBox statUpper, string min, string max)
         {
@@ -777,6 +755,38 @@ namespace SWSH_OWRNG_Generator_GUI
             statLower.Text = min;
             statUpper.Clear();
             statUpper.Text = max;
+        }
+
+        private void atkJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            StatJudgeFilter(atkMin, atkMax, atkJudgeFilter.Text);
+        }
+
+        private void StatJudgeFilter(TextBox statL, TextBox statU, string judge)
+        {
+            switch (judge)
+            {
+                case "No Good":
+                    SetFilterStats(statL, statU, "0", "0");
+                    break;
+                case "Decent":
+                    SetFilterStats(statL, statU, "1", "15");
+                    break;
+                case "Pretty Good":
+                    SetFilterStats(statL, statU, "16", "25");
+                    break;
+                case "Very Good":
+                    SetFilterStats(statL, statU, "26", "29");
+                    break;
+                case "Fantastic":
+                    SetFilterStats(statL, statU, "30", "30");
+                    break;
+                case "Best":
+                    SetFilterStats(statL, statU, "31", "31");
+                    break;
+                default:
+                    break;
+            }
         }
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -152,6 +152,83 @@ namespace SWSH_OWRNG_Generator_GUI
             {
                 if (i < 0) textBox.Text = "0";
                 if (i > 31) textBox.Text = "31";
+
+                switch (textBox.Name)
+                {
+                    case "hpMin":
+                    case "hpMax":
+                        JudgeFilterCompareIVs(UInt16.Parse(hpMin.Text), UInt16.Parse(hpMax.Text), hpJudgeFilter, e);
+                        break;
+
+                    case "atkMin":
+                    case "atkMax":
+                        JudgeFilterCompareIVs(UInt16.Parse(atkMin.Text), UInt16.Parse(atkMax.Text), atkJudgeFilter, e);
+                        break;
+
+                    case "defMin":
+                    case "defMax":
+                        JudgeFilterCompareIVs(UInt16.Parse(defMin.Text), UInt16.Parse(defMax.Text), defJudgeFilter, e);
+                        break;
+
+                    case "spaMin":
+                    case "spaMax":
+                        JudgeFilterCompareIVs(UInt16.Parse(spaMin.Text), UInt16.Parse(spaMax.Text), spaJudgeFilter, e);
+                        break;
+
+                    case "spdMin":
+                    case "spdMax":
+                        JudgeFilterCompareIVs(UInt16.Parse(spdMin.Text), UInt16.Parse(spdMax.Text), spdJudgeFilter, e);
+                        break;
+
+                    case "speMin":
+                    case "speMax":
+                        JudgeFilterCompareIVs(UInt16.Parse(speMin.Text), UInt16.Parse(speMax.Text), speJudgeFilter, e);
+                        break;
+                }
+            }
+        }
+
+        private void JudgeFilterCompareIVs(uint min, uint max, ComboBox box, EventArgs e)
+        {
+            if (min == 0 && max == 0)
+            {
+                box.SelectedIndexChanged -= this.JudgeFilter_SelectedIndexChanged;
+                box.SelectedIndex = 0;
+                box.SelectedIndexChanged += this.JudgeFilter_SelectedIndexChanged;
+            }
+            else if (min >= 1 && min <= 15 && max >= 1 && max <= 15)
+            {
+                box.SelectedIndexChanged -= this.JudgeFilter_SelectedIndexChanged;
+                box.SelectedIndex = 1;
+                box.SelectedIndexChanged += this.JudgeFilter_SelectedIndexChanged;
+            }
+            else if (min >= 16 && min <= 25 && max >= 16 && max <= 25)
+            {
+                box.SelectedIndexChanged -= this.JudgeFilter_SelectedIndexChanged;
+                box.SelectedIndex = 2;
+                box.SelectedIndexChanged += this.JudgeFilter_SelectedIndexChanged;
+            }
+            else if (min >= 26 && min <= 29 && max >= 26 && max <= 29)
+            {
+                box.SelectedIndexChanged -= this.JudgeFilter_SelectedIndexChanged;
+                box.SelectedIndex = 3;
+                box.SelectedIndexChanged += this.JudgeFilter_SelectedIndexChanged;
+            }
+            else if (min == 30 && max == 30)
+            {
+                box.SelectedIndexChanged -= this.JudgeFilter_SelectedIndexChanged;
+                box.SelectedIndex = 4;
+                box.SelectedIndexChanged += this.JudgeFilter_SelectedIndexChanged;
+            }
+            else if (min == 31 && max == 31)
+            {
+                box.SelectedIndexChanged -= this.JudgeFilter_SelectedIndexChanged;
+                box.SelectedIndex = 5;
+                box.SelectedIndexChanged += this.JudgeFilter_SelectedIndexChanged;
+            }
+            else
+            {
+                box.SelectedIndex = -1;
             }
         }
 
@@ -745,34 +822,35 @@ namespace SWSH_OWRNG_Generator_GUI
                     break;
             }
         }
-        private void HpJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            IvJudgeFilter(hpMin, hpMax, hpJudgeFilter.Text);
-        }
 
-        private void AtkJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        private void JudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
         {
-            IvJudgeFilter(atkMin, atkMax, atkJudgeFilter.Text);
-        }
+            switch (((ComboBox)sender).Name)
+            {
+                case "hpJudgeFilter":
+                    IvJudgeFilter(hpMin, hpMax, hpJudgeFilter.Text);
+                    break;
 
-        private void DefJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            IvJudgeFilter(defMin, defMax, defJudgeFilter.Text);
-        }
+                case "atkJudgeFilter":
+                    IvJudgeFilter(atkMin, atkMax, atkJudgeFilter.Text);
+                    break;
 
-        private void SpaJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            IvJudgeFilter(spaMin, spaMax, spaJudgeFilter.Text);
-        }
+                case "defJudgeFilter":
+                    IvJudgeFilter(defMin, defMax, defJudgeFilter.Text);
+                    break;
 
-        private void SpdJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            IvJudgeFilter(spdMin, spdMax, spdJudgeFilter.Text);
-        }
+                case "spaJudgeFilter":
+                    IvJudgeFilter(spaMin, spaMax, spaJudgeFilter.Text);
+                    break;
 
-        private void SpeJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            IvJudgeFilter(speMin, speMax, speJudgeFilter.Text);
+                case "spdJudgeFilter":
+                    IvJudgeFilter(spdMin, spdMax, spdJudgeFilter.Text);
+                    break;
+
+                case "speJudgeFilter":
+                    IvJudgeFilter(speMin, speMax, speJudgeFilter.Text);
+                    break;
+            }
         }
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -7,7 +7,7 @@ using System.Windows.Forms;
 
 namespace SWSH_OWRNG_Generator_GUI
 {
-    public partial class MainWindow : System.Windows.Forms.Form
+    public partial class MainWindow : Form
     {
         public MainWindow()
         {
@@ -119,7 +119,6 @@ namespace SWSH_OWRNG_Generator_GUI
             {
                 textBox.Text = "0";
             }
-
         }
 
         private void SetToZero_LostFocus(object sender, EventArgs e)
@@ -438,7 +437,6 @@ namespace SWSH_OWRNG_Generator_GUI
             {
                 e.KeyChar = '0';
             }
-
             else if (e.KeyChar == '.')
             {
                 e.KeyChar = '1';
@@ -555,9 +553,9 @@ namespace SWSH_OWRNG_Generator_GUI
             });
 
             List<Frame> Frames = await Task.Run(() => Generator.Generate(
-                s0, s1, advances, TID, SID, ShinyCharm, MarkCharm, Weather, Static, Fishing, HeldItem, DesiredMark, DesiredShiny,DesiredNature,
-                LevelMin, LevelMax, SlotMin, SlotMax, MinIVs, MaxIVs, IsAbilityLocked, EMCount, KOCount, FlawlessIVs, IsCuteCharm, 
-                TIDSIDSearch, progress
+                s0, s1, advances, TID, SID, ShinyCharm, MarkCharm, Weather, Static, Fishing, HeldItem, DesiredMark, DesiredShiny,
+                DesiredNature, LevelMin, LevelMax, SlotMin, SlotMax, MinIVs, MaxIVs, IsAbilityLocked, EMCount, KOCount, FlawlessIVs,
+                IsCuteCharm, TIDSIDSearch, progress
             ));
             BindingSource Source = new BindingSource { DataSource = Frames };
             Results.DataSource = Source;
@@ -710,7 +708,7 @@ namespace SWSH_OWRNG_Generator_GUI
                 this.RetailAdvancesTrackerResultState0.UseSystemPasswordChar = false;
                 this.RetailAdvancesTrackerResultState1.UseSystemPasswordChar = false;
             }
-            
+
         }
 
         private void SetIvFilters(TextBox statLower, TextBox statUpper, string min, string max)

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -745,6 +745,51 @@ namespace SWSH_OWRNG_Generator_GUI
             speMax.Text = "31";
         }
 
-        
+        private void HpJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            switch (hpJudgeFilter.Text)
+            {
+                case "No Good":
+                    hpMin.Clear();
+                    hpMin.Text = "0";
+                    hpMax.Clear();
+                    hpMax.Text = "0";
+                    break;
+                case "Decent":
+                    hpMin.Clear();
+                    hpMin.Text = "1";
+                    hpMax.Clear();
+                    hpMax.Text = "15";
+                    break;
+                case "Pretty Good":
+                    hpMin.Clear();
+                    hpMin.Text = "16";
+                    hpMax.Clear();
+                    hpMax.Text = "25";
+                    break;
+                case "Very Good":
+                    hpMin.Clear();
+                    hpMin.Text = "26";
+                    hpMax.Clear();
+                    hpMax.Text = "29";
+                    break;
+                case "Fantastic":
+                    hpMin.Clear();
+                    hpMin.Text = "30";
+                    hpMax.Clear();
+                    hpMax.Text = "30";
+                    break;
+                case "Best":
+                    hpMin.Clear();
+                    hpMin.Text = "31";
+                    hpMax.Clear();
+                    hpMax.Text = "31";
+                    break;
+                default:
+                    break;
+            }
+        }
+
+
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -418,6 +418,16 @@ namespace SWSH_OWRNG_Generator_GUI
         {
             string s = "";
 
+            if (e.KeyChar == ',')
+            {
+                e.KeyChar = '0';
+            }
+
+            else if (e.KeyChar == '.')
+            {
+                e.KeyChar = '1';
+            }
+
             s += e.KeyChar;
 
             byte[] b = Encoding.ASCII.GetBytes(s);

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -745,10 +745,6 @@ namespace SWSH_OWRNG_Generator_GUI
             speMax.Text = "31";
         }
 
-        private void HpJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            StatJudgeFilter(hpMin, hpMax, hpJudgeFilter.Text);
-        }
         private void SetFilterStats(TextBox statLower, TextBox statUpper, string min, string max)
         {
             statLower.Clear();
@@ -757,7 +753,13 @@ namespace SWSH_OWRNG_Generator_GUI
             statUpper.Text = max;
         }
 
-        private void atkJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+
+        private void HpJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            StatJudgeFilter(hpMin, hpMax, hpJudgeFilter.Text);
+        }
+        
+        private void AtkJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
         {
             StatJudgeFilter(atkMin, atkMax, atkJudgeFilter.Text);
         }
@@ -787,6 +789,26 @@ namespace SWSH_OWRNG_Generator_GUI
                 default:
                     break;
             }
+        }
+
+        private void defJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            StatJudgeFilter(defMin, defMax, defJudgeFilter.Text);
+        }
+
+        private void spaJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            StatJudgeFilter(spaMin, spaMax, spaJudgeFilter.Text);
+        }
+
+        private void spdJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            StatJudgeFilter(spdMin, spdMax, spdJudgeFilter.Text);
+        }
+
+        private void speJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            StatJudgeFilter(speMin, speMax, speJudgeFilter.Text);
         }
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/MainWindow.cs
+++ b/SWSH_OWRNG_Generator_GUI/MainWindow.cs
@@ -205,31 +205,37 @@ namespace SWSH_OWRNG_Generator_GUI
                 case "hpFilter":
                     hpMin.Text = "0";
                     hpMax.Text = "31";
+                    hpJudgeFilter.SelectedIndex = -1;
                     break;
 
                 case "atkFilter":
                     atkMin.Text = "0";
                     atkMax.Text = "31";
+                    atkJudgeFilter.SelectedIndex = -1;
                     break;
 
                 case "defFilter":
                     defMin.Text = "0";
                     defMax.Text = "31";
+                    defJudgeFilter.SelectedIndex = -1;
                     break;
 
                 case "spaFilter":
                     spaMin.Text = "0";
                     spaMax.Text = "31";
+                    spaJudgeFilter.SelectedIndex = -1;
                     break;
 
                 case "spdFilter":
                     spdMin.Text = "0";
                     spdMax.Text = "31";
+                    spdJudgeFilter.SelectedIndex = -1;
                     break;
 
                 case "speFilter":
                     speMin.Text = "0";
                     speMax.Text = "31";
+                    speJudgeFilter.SelectedIndex = -1;
                     break;
             }
         }
@@ -698,54 +704,7 @@ namespace SWSH_OWRNG_Generator_GUI
             
         }
 
-        private void HpResetFilter_Click(object sender, EventArgs e)
-        {
-            hpMin.Clear();
-            hpMin.Text = "0";
-            hpMax.Clear();
-            hpMax.Text = "31";
-        }
-        private void AtkResetFilter_Click(object sender, EventArgs e)
-        {
-            atkMin.Clear();
-            atkMin.Text = "0";
-            atkMax.Clear();
-            atkMax.Text = "31";
-        }
-
-        private void DefResetFilter_Click(object sender, EventArgs e)
-        {
-            defMin.Clear();
-            defMin.Text = "0";
-            defMax.Clear();
-            defMax.Text = "31";
-        }
-
-        private void SpaResetFilter_Click(object sender, EventArgs e)
-        {
-            spaMin.Clear();
-            spaMin.Text = "0";
-            spaMax.Clear();
-            spaMax.Text = "31";
-        }
-
-        private void SpdResetFilter_Click(object sender, EventArgs e)
-        {
-            spdMin.Clear();
-            spdMin.Text = "0";
-            spdMax.Clear();
-            spdMax.Text = "31";
-        }
-
-        private void SpeResetFilter_Click(object sender, EventArgs e)
-        {
-            speMin.Clear();
-            speMin.Text = "0";
-            speMax.Clear();
-            speMax.Text = "31";
-        }
-
-        private void SetFilterStats(TextBox statLower, TextBox statUpper, string min, string max)
+        private void SetIvFilters(TextBox statLower, TextBox statUpper, string min, string max)
         {
             statLower.Clear();
             statLower.Text = min;
@@ -753,62 +712,60 @@ namespace SWSH_OWRNG_Generator_GUI
             statUpper.Text = max;
         }
 
-
-        private void HpJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            StatJudgeFilter(hpMin, hpMax, hpJudgeFilter.Text);
-        }
-        
-        private void AtkJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
-        {
-            StatJudgeFilter(atkMin, atkMax, atkJudgeFilter.Text);
-        }
-
-        private void StatJudgeFilter(TextBox statL, TextBox statU, string judge)
+        private void IvJudgeFilter(TextBox statL, TextBox statU, string judge)
         {
             switch (judge)
             {
                 case "No Good":
-                    SetFilterStats(statL, statU, "0", "0");
+                    SetIvFilters(statL, statU, "0", "0");
                     break;
                 case "Decent":
-                    SetFilterStats(statL, statU, "1", "15");
+                    SetIvFilters(statL, statU, "1", "15");
                     break;
                 case "Pretty Good":
-                    SetFilterStats(statL, statU, "16", "25");
+                    SetIvFilters(statL, statU, "16", "25");
                     break;
                 case "Very Good":
-                    SetFilterStats(statL, statU, "26", "29");
+                    SetIvFilters(statL, statU, "26", "29");
                     break;
                 case "Fantastic":
-                    SetFilterStats(statL, statU, "30", "30");
+                    SetIvFilters(statL, statU, "30", "30");
                     break;
                 case "Best":
-                    SetFilterStats(statL, statU, "31", "31");
+                    SetIvFilters(statL, statU, "31", "31");
                     break;
                 default:
                     break;
             }
         }
-
-        private void defJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        private void HpJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
         {
-            StatJudgeFilter(defMin, defMax, defJudgeFilter.Text);
+            IvJudgeFilter(hpMin, hpMax, hpJudgeFilter.Text);
         }
 
-        private void spaJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        private void AtkJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
         {
-            StatJudgeFilter(spaMin, spaMax, spaJudgeFilter.Text);
+            IvJudgeFilter(atkMin, atkMax, atkJudgeFilter.Text);
         }
 
-        private void spdJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        private void DefJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
         {
-            StatJudgeFilter(spdMin, spdMax, spdJudgeFilter.Text);
+            IvJudgeFilter(defMin, defMax, defJudgeFilter.Text);
         }
 
-        private void speJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        private void SpaJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
         {
-            StatJudgeFilter(speMin, speMax, speJudgeFilter.Text);
+            IvJudgeFilter(spaMin, spaMax, spaJudgeFilter.Text);
+        }
+
+        private void SpdJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            IvJudgeFilter(spdMin, spdMax, spdJudgeFilter.Text);
+        }
+
+        private void SpeJudgeFilter_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            IvJudgeFilter(speMin, speMax, speJudgeFilter.Text);
         }
     }
 }

--- a/SWSH_OWRNG_Generator_GUI/SeedFinder.cs
+++ b/SWSH_OWRNG_Generator_GUI/SeedFinder.cs
@@ -126,6 +126,16 @@ namespace SWSH_OWRNG_Generator_GUI
         {
             string s = "";
 
+            if (e.KeyChar == ',')
+            {
+                e.KeyChar = '0';
+            }
+
+            else if (e.KeyChar == '.')
+            {
+                e.KeyChar = '1';
+            }
+
             s += e.KeyChar;
 
             byte[] b = Encoding.ASCII.GetBytes(s);


### PR DESCRIPTION
This PR will add IV judge filtering for non-CFW players to filter frames using the in-game judge function. Dropdown combo boxes were added to the right of the current IV filtering buttons and can be reset with the existing reset buttons on the labels. 

The PR will also add a nature filtering dropdown option below the shiny selection dropdown. Some changes were made in Generator.cs to account for that, like adding an additional parameter in Generate() and a PassesNatureFilter() method similar to PassesMarkFilter(), as a result the results of the mark check on like 147 `if (!PassesMarkFilter(Mark, DesiredMark))` are carried over for the nature check.

The tab indexes for the new filter options have been adjusted to follow the pattern of the buttons around them. Let me know if there's anything I should change and no rush checking this.