### PR TITLE
Remove +1 to NPC count

### DIFF
--- a/SWSH_OWRNG_Generator.WinForms/MainWindow.cs
+++ b/SWSH_OWRNG_Generator.WinForms/MainWindow.cs
@@ -565,7 +565,7 @@ namespace SWSH_OWRNG_Generator.WinForms
                 uint NPCs = 0;
                 if (CheckMenuClose.Checked)
                 {
-                    NPCs = uint.Parse(InputNPCs.Text) + 1;
+                    NPCs = uint.Parse(InputNPCs.Text);
                 }
                 Core.Overworld.Filter Filters = new()
                 {

--- a/SWSH_OWRNG_Generator.WinForms/Subforms/Cram-o-matic/Cram-o-matic.cs
+++ b/SWSH_OWRNG_Generator.WinForms/Subforms/Cram-o-matic/Cram-o-matic.cs
@@ -34,7 +34,7 @@ namespace SWSH_OWRNG_Generator.WinForms
             uint NPCs = 0;
             if (CheckMenuClose.Checked)
             {
-                NPCs = uint.Parse(InputNPCs.Text) + 1;
+                NPCs = uint.Parse(InputNPCs.Text);
             }
 
 

--- a/SWSH_OWRNG_Generator.WinForms/Subforms/Loto-ID/Loto-ID.cs
+++ b/SWSH_OWRNG_Generator.WinForms/Subforms/Loto-ID/Loto-ID.cs
@@ -65,7 +65,7 @@ namespace SWSH_OWRNG_Generator.WinForms
             MainWindow.Pad(InputNPCs, '0', 1);
             uint NPCs = 0;
             if (CheckMenuClose.Checked)
-                NPCs = uint.Parse(InputNPCs.Text) + 1;
+                NPCs = uint.Parse(InputNPCs.Text);
 
             MainWindow.Pad(InputMaxAdv, '0', 1);
             ulong advances = ulong.Parse(InputMaxAdv.Text);

--- a/SWSH_OWRNG_Generator.WinForms/Subforms/MenuCloseTimeline/MenuCloseTimeline.cs
+++ b/SWSH_OWRNG_Generator.WinForms/Subforms/MenuCloseTimeline/MenuCloseTimeline.cs
@@ -30,7 +30,7 @@ namespace SWSH_OWRNG_Generator.WinForms
             ulong s0 = ulong.Parse(InputState0.Text, NumberStyles.AllowHexSpecifier);
             ulong s1 = ulong.Parse(InputState1.Text, NumberStyles.AllowHexSpecifier);
             MainWindow.Pad(InputNPCs, '0', 1);
-            uint NPCs = uint.Parse(InputNPCs.Text) + 1;
+            uint NPCs = uint.Parse(InputNPCs.Text);
 
             MainWindow.Pad(InputMaxAdv, '0', 1);
             ulong advances = ulong.Parse(InputMaxAdv.Text);


### PR DESCRIPTION
I believe the reason for this existing was the assumption that the player will always act as a rand(91) npc object, this isnt actually true as there are fully 0 NPC areas. I'm unsure if you'd like to handle this differently as it breaks parity with npc counts from a previous version.