### PR TITLE
Fix Menu Close Fidget Logic

### DIFF
--- a/SWSH_OWRNG_Generator.Core/Enums/MenuClose.cs
+++ b/SWSH_OWRNG_Generator.Core/Enums/MenuClose.cs
@@ -4,7 +4,5 @@
     {
         Regular,
         HoldingDirection,
-        CaveRegular,
-        CaveHoldingDirection
     }
 }

--- a/SWSH_OWRNG_Generator.Core/MenuClose/Generator.cs
+++ b/SWSH_OWRNG_Generator.Core/MenuClose/Generator.cs
@@ -10,19 +10,11 @@ namespace SWSH_OWRNG_Generator.Core.MenuClose
             {
                 rng.NextInt(91);
             }
-            rng.Next();
-            rng.NextInt(60);
-            if (Mode == (byte)MenuCloseType.HoldingDirection)
+            if (Mode != (byte)MenuCloseType.HoldingDirection)
             {
-                rng.NextInt(360);
-            }
-            else if (Mode == (byte)MenuCloseType.CaveRegular)
-            {
-                // Not implemented
-            }
-            else if (Mode == (byte)MenuCloseType.CaveHoldingDirection)
-            {
-                // Not implemented
+                // these rng calls are not correct in all weathers as player fidget logic can change based on weather
+                rng.Next();
+                rng.NextInt(60);
             }
             return ref rng;
         }

--- a/SWSH_OWRNG_Generator.Core/MenuClose/Generator.cs
+++ b/SWSH_OWRNG_Generator.Core/MenuClose/Generator.cs
@@ -12,7 +12,7 @@ namespace SWSH_OWRNG_Generator.Core.MenuClose
             }
             if (Mode != (byte)MenuCloseType.HoldingDirection)
             {
-                // these rng calls are not correct in all weathers as player fidget logic can change based on weather
+                // These rng calls are not correct in all weathers as player fidget logic can change based on weather
                 rng.Next();
                 rng.NextInt(60);
             }


### PR DESCRIPTION
simply only does the player fidget rands
```cs
rng.Next();
rng.NextInt(60);
```
when the ``MenuCloseType`` is not ``HoldingDirection`` as fidgets do not happen when holding a direction. additionally removes the erroneous rand(360) for this case & removes the unimplemented cave types as they are not actually unique. this change is not tested as I do not have a build environment set up but should logically be fine. it's worth noting that currently there is never a case where the value of ``Mode`` is not ``MenuCloseType.Regular`` as the only place where this is an option (``MenuCloseTimeline`` subform) does not actually consider the user input for the "Holding direction?" checkbox.